### PR TITLE
Add generic derivation for cell decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The generic derivation for cell decoders also supports renaming and deriving ins
 import fs2.data.csv.generic.semiauto._
 
 sealed trait Advanced
-@CsvName("Active") case object On extends Advanced
+@CsvValue("Active") case object On extends Advanced
 case class Unknown(name: String) extends Advanced
 
 implicit val unknownDecoder = deriveCellDecoder[Unknown] // works as we have an implicit CellDecoder[String]

--- a/csv/generic/src/fs2/data/csv/generic/CsvName.scala
+++ b/csv/generic/src/fs2/data/csv/generic/CsvName.scala
@@ -1,0 +1,9 @@
+package fs2.data.csv.generic
+
+import scala.annotation.Annotation
+
+/**
+ * Mark an object of sealed trait to have a different representation in CSV than the name of the type.
+ * @param name the name to expect in the CSV
+ */
+case class CsvName(name: String) extends Annotation

--- a/csv/generic/src/fs2/data/csv/generic/CsvValue.scala
+++ b/csv/generic/src/fs2/data/csv/generic/CsvValue.scala
@@ -4,6 +4,6 @@ import scala.annotation.Annotation
 
 /**
  * Mark an object of sealed trait to have a different representation in CSV than the name of the type.
- * @param name the name to expect in the CSV
+ * @param value the value to expect in the CSV
  */
-case class CsvName(name: String) extends Annotation
+case class CsvValue(value: String) extends Annotation

--- a/csv/generic/src/fs2/data/csv/generic/DerivedCellDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/DerivedCellDecoder.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data
+package csv
+package generic
+
+import cats.implicits._
+import shapeless._
+import shapeless.labelled._
+
+trait DerivedCellDecoder[T] extends CellDecoder[T]
+
+object DerivedCellDecoder extends DerivedCellDecoderInstances0 {
+
+  // Unary Products
+
+  final implicit def unaryProductDecoder[A <: Product, L <: HList, H](implicit
+                                                                      gen: Generic.Aux[A, L],
+                                                                      ev: =:=[H :: HNil, L],
+                                                                      cc: CellDecoder[H],
+                                                                     ): DerivedCellDecoder[A] = s =>
+    cc(s).map(v => gen.from(v :: HNil))
+
+  // Coproducts
+
+  final implicit def coproductDecoder[T, Repr <: Coproduct](implicit
+                                                            gen: LabelledGeneric.Aux[T, Repr],
+                                                            cc: Lazy[DerivedCellDecoder[Repr]]): DerivedCellDecoder[T] = s =>
+    cc.value(s).map(gen.from(_))
+
+  final implicit val decodeCNil: DerivedCellDecoder[CNil] = (_: String) => Left(new DecoderError("CNil"))
+
+  final implicit def decodeCCons[K <: Symbol, L, R <: Coproduct](implicit
+                                                                 witK: Witness.Aux[K],
+                                                                 decodeL: CellDecoder[L],
+                                                                 decodeR: Lazy[DerivedCellDecoder[R]]
+                                                                ): DerivedCellDecoder[FieldType[K, L] :+: R] = s =>
+    decodeL(s)
+      .map[FieldType[K, L] :+: R](v => Inl(field[K](v)))
+      .handleErrorWith(_ => decodeR.value(s).map(Inr(_)))
+
+}
+
+trait DerivedCellDecoderInstances0 extends DerivedCellDecoderInstances1 {
+  final implicit def decodeCConsObjAnnotated[K <: Symbol, L, R <: Coproduct](implicit
+                                                                    witK: Witness.Aux[K],
+                                                                    witL: Witness.Aux[L],
+                                                                    annotation: Annotation[CsvName, L],
+                                                                    gen: Generic.Aux[L, HNil],
+                                                                    decodeR: Lazy[DerivedCellDecoder[R]]
+                                                                   ): DerivedCellDecoder[FieldType[K, L] :+: R] = s =>
+    if (annotation().name == s) Inl(field[K](witL.value)).asRight
+    else decodeR.value(s).map(Inr(_))
+}
+
+trait DerivedCellDecoderInstances1 {
+  final implicit def decodeCConsObj[K <: Symbol, L, R <: Coproduct](implicit
+                                                                    witK: Witness.Aux[K],
+                                                                    witL: Witness.Aux[L],
+                                                                    gen: Generic.Aux[L, HNil],
+                                                                    decodeR: Lazy[DerivedCellDecoder[R]]
+                                                                   ): DerivedCellDecoder[FieldType[K, L] :+: R] = s =>
+    if (witK.value.name == s) Inl(field[K](witL.value)).asRight
+    else decodeR.value(s).map(Inr(_))
+}

--- a/csv/generic/src/fs2/data/csv/generic/DerivedCellDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/DerivedCellDecoder.scala
@@ -57,13 +57,13 @@ object DerivedCellDecoder extends DerivedCellDecoderInstances0 {
 
 trait DerivedCellDecoderInstances0 extends DerivedCellDecoderInstances1 {
   final implicit def decodeCConsObjAnnotated[K <: Symbol, L, R <: Coproduct](implicit
-                                                                    witK: Witness.Aux[K],
-                                                                    witL: Witness.Aux[L],
-                                                                    annotation: Annotation[CsvName, L],
-                                                                    gen: Generic.Aux[L, HNil],
-                                                                    decodeR: Lazy[DerivedCellDecoder[R]]
+                                                                             witK: Witness.Aux[K],
+                                                                             witL: Witness.Aux[L],
+                                                                             annotation: Annotation[CsvValue, L],
+                                                                             gen: Generic.Aux[L, HNil],
+                                                                             decodeR: Lazy[DerivedCellDecoder[R]]
                                                                    ): DerivedCellDecoder[FieldType[K, L] :+: R] = s =>
-    if (annotation().name == s) Inl(field[K](witL.value)).asRight
+    if (annotation().value == s) Inl(field[K](witL.value)).asRight
     else decodeR.value(s).map(Inr(_))
 }
 

--- a/csv/generic/src/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/semiauto.scala
@@ -28,4 +28,7 @@ object semiauto {
   def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, String] =
     T.value
 
+  def deriveCellDecoder[T](implicit T: Lazy[DerivedCellDecoder[T]]): CellDecoder[T] =
+    T.value
+
 }

--- a/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
@@ -16,8 +16,8 @@ case class Numbered(n: Int) extends Complex
 case class Unknown(state: String) extends Complex
 
 sealed trait Alphabet
-@CsvName("A") case object Alpha extends Alphabet
-@CsvName("B") case object Beta extends Alphabet
+@CsvValue("A") case object Alpha extends Alphabet
+@CsvValue("B") case object Beta extends Alphabet
 case object Gamma extends Alphabet
 
 case class IntWrapper(value: Int)
@@ -51,7 +51,7 @@ class CellDecoderTest extends FlatSpec with Matchers with EitherValues {
   it should "respect @CsvName annotations" in {
     val alphabetDecoder: CellDecoder[Alphabet] = semiauto.deriveCellDecoder
 
-    Annotation[CsvName, Alpha.type].apply().name shouldBe "A"
+    Annotation[CsvValue, Alpha.type].apply().value shouldBe "A"
 
     alphabetDecoder("A") shouldBe Right(Alpha)
     alphabetDecoder("B") shouldBe Right(Beta)

--- a/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
@@ -1,0 +1,74 @@
+package fs2.data.csv.generic
+
+import cats.implicits._
+import fs2.data.csv.{CellDecoder, DecoderResult}
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import shapeless.Annotation
+
+sealed trait Simple
+case object On extends Simple
+case object Off extends Simple
+
+sealed trait Complex
+case object Active extends Complex
+object Inactive extends Complex
+case class Numbered(n: Int) extends Complex
+case class Unknown(state: String) extends Complex
+
+sealed trait Alphabet
+@CsvName("A") case object Alpha extends Alphabet
+@CsvName("B") case object Beta extends Alphabet
+case object Gamma extends Alphabet
+
+case class IntWrapper(value: Int)
+case class IntResultWrapper(value: DecoderResult[Int])
+case class Thing(value: String, extra: Int)
+case class ThingWrapper(thing: Thing)
+case class Wrapper[T](value: T)
+
+class CellDecoderTest extends FlatSpec with Matchers with EitherValues {
+
+  "derivation for coproducts" should "work out of the box for enum-style sealed traits" in {
+    val simpleDecoder: CellDecoder[Simple] = semiauto.deriveCellDecoder
+
+    simpleDecoder("On") shouldBe Right(On)
+    simpleDecoder("Off") shouldBe Right(Off)
+    simpleDecoder("foo").isLeft shouldBe true
+  }
+
+  it should "handle non-case object cases" in {
+    implicit val numberedDecoder: CellDecoder[Numbered] = CellDecoder[Int].map(Numbered)
+    implicit val unknownDecoder: CellDecoder[Unknown] = CellDecoder[String].map(Unknown)
+    val complexDecoder: CellDecoder[Complex] = semiauto.deriveCellDecoder
+
+    complexDecoder("Active") shouldBe Right(Active)
+    complexDecoder("Inactive") shouldBe Right(Inactive)
+    complexDecoder("inactive") shouldBe Right(Unknown("inactive"))
+    complexDecoder("7") shouldBe Right(Numbered(7))
+    complexDecoder("foo") shouldBe Right(Unknown("foo"))
+  }
+
+  it should "respect @CsvName annotations" in {
+    val alphabetDecoder: CellDecoder[Alphabet] = semiauto.deriveCellDecoder
+
+    Annotation[CsvName, Alpha.type].apply().name shouldBe "A"
+
+    alphabetDecoder("A") shouldBe Right(Alpha)
+    alphabetDecoder("B") shouldBe Right(Beta)
+    alphabetDecoder("Gamma") shouldBe Right(Gamma)
+    alphabetDecoder("foobar").isLeft shouldBe true
+  }
+
+  "derivation for unary products" should "work for standard types" in {
+    semiauto.deriveCellDecoder[IntResultWrapper].apply("7") shouldBe Right(IntResultWrapper(Right(7)))
+  }
+
+  it should "work for types with implicit decoder" in {
+    implicit val thingDecoder: CellDecoder[Thing] = CellDecoder[String].map(Thing(_, 7))
+    semiauto.deriveCellDecoder[ThingWrapper].apply("cell") shouldBe Right(ThingWrapper(Thing("cell", 7)))
+  }
+
+  it should "work for types with arguments" in {
+    semiauto.deriveCellDecoder[Wrapper[Int]].apply("7") shouldBe Right(Wrapper(7))
+  }
+}


### PR DESCRIPTION
* derives cell decoders for coproducts where each case is
  * an `object` or 
  * a `case object` or
  * has an implicit `CellDecoder` instance
* allows changing the expected value in CSV for objects by using the `@CsvName` annotation
* derives cell decoders for unary product types (case classes with one field)

See tests for some examples.