### PR TITLE
Auto derivation for csv-generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ val rows = withh.through(decodeRow[IO, String, Row])
 println(rows.compile.toList.unsafeRunSync())
 ```
 
+There's also support for full auto-derivation, just `import fs2.data.csv.generic.auto._` for everything, `import fs2.data.csv.generic.auto.row._` for `RowDecoder` support only or `import fs2.data.csv.generic.auto.csvrow._` for `CsvRowDecoder` support.
+
 [fs2]: https://fs2.io/
 [circe]: https://circe.github.io/circe/
 [shapeless]: https://github.com/milessabin/shapeless

--- a/build.sc
+++ b/build.sc
@@ -73,7 +73,24 @@ class CsvModule(val crossScalaVersion: String) extends Fs2DataModule with CrossS
   object generic extends Fs2DataModule with PublishModule {
     def scalaVersion = outer.scalaVersion
     def moduleDeps = Seq(outer)
-    def ivyDeps = Agg(ivy"com.chuusai::shapeless:$shapelessVersion")
+    def ivyDeps = Agg(
+      ivy"com.chuusai::shapeless:$shapelessVersion",
+      ivy"org.scala-lang:scala-reflect:${scalaVersion()}"
+    )
+
+    override def scalacOptions = T {
+      if (scalaVersion().startsWith("2.13"))
+        Seq("-Ymacro-annotations")
+      else
+        Seq()
+    }
+
+    override def scalacPluginIvyDeps = T {
+      if (scalaVersion().startsWith("2.13"))
+        super.scalacPluginIvyDeps()
+      else
+        super.scalacPluginIvyDeps() ++ Agg(ivy"org.scalamacros:::paradise:2.1.1")
+    }
 
     def publishVersion = fs2DataVersion
 

--- a/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
+++ b/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package fs2.data.csv.generic
 
 import fs2.data.csv.{CsvRowDecoder, Exported, RowDecoder}

--- a/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
+++ b/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
@@ -1,0 +1,30 @@
+package fs2.data.csv.generic
+
+import fs2.data.csv.{CsvRowDecoder, Exported, RowDecoder}
+
+import scala.reflect.macros.blackbox
+
+/**
+ * Macros used to circumvent divergence checker restrictions in the compiler. Inspired by pureconfig and circe.
+ */
+class ExportMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  final def exportRowDecoder[A](implicit a: c.WeakTypeTag[A]): c.Expr[Exported[RowDecoder[A]]] = {
+    c.typecheck(q"_root_.shapeless.lazily[_root_.fs2.data.csv.generic.DerivedRowDecoder[$a]]", silent = true) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type $a")
+      case t =>
+        c.Expr[Exported[RowDecoder[A]]](
+          q"new _root_.fs2.data.csv.Exported($t: _root_.fs2.data.csv.RowDecoder[$a])")
+    }
+  }
+
+  final def exportCsvRowDecoder[A](implicit a: c.WeakTypeTag[A]): c.Expr[Exported[CsvRowDecoder[A, String]]] = {
+    c.typecheck(q"_root_.shapeless.lazily[_root_.fs2.data.csv.generic.DerivedCsvRowDecoder[$a]]", silent = false) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type $a")
+      case t =>
+        c.Expr[Exported[CsvRowDecoder[A, String]]](
+          q"new _root_.fs2.data.csv.Exported($t: _root_.fs2.data.csv.CsvRowDecoder[$a, ${weakTypeTag[String]}])")
+    }
+  }
+}

--- a/csv/generic/src/fs2/data/csv/generic/auto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/auto.scala
@@ -1,0 +1,18 @@
+package fs2.data.csv.generic
+
+import fs2.data.csv.{CsvRowDecoder, Exported, RowDecoder}
+
+import scala.language.experimental.macros
+
+trait AutoDerivedRowDecoders {
+  implicit def exportRowDecoder[A]: Exported[RowDecoder[A]] = macro ExportMacros.exportRowDecoder[A]
+}
+
+trait AutoDerivedCsvRowDecoders {
+  implicit def exportCsvRowDecoder[A]: Exported[CsvRowDecoder[A, String]] = macro ExportMacros.exportCsvRowDecoder[A]
+}
+
+object auto extends AutoDerivedRowDecoders with AutoDerivedCsvRowDecoders {
+  object row extends AutoDerivedRowDecoders
+  object csvrow extends AutoDerivedCsvRowDecoders
+}

--- a/csv/generic/src/fs2/data/csv/generic/auto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/auto.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package fs2.data.csv.generic
 
 import fs2.data.csv.{CsvRowDecoder, Exported, RowDecoder}

--- a/csv/generic/test/src/fs2/data/csv/generic/AutoDerivationTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/AutoDerivationTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2.data.csv.generic
+
+import cats.data.NonEmptyList
+import fs2.data.csv.{CsvRow, CsvRowDecoder, RowDecoder}
+import org.scalatest._
+
+class AutoDerivationTest extends FlatSpec with Matchers {
+
+  val csvRow = new CsvRow(NonEmptyList.of("1", "test", "42"), Some(NonEmptyList.of("i", "s", "j")))
+  val plainRow = CsvRow.fromNel(NonEmptyList.of("1", "test", "42"))
+
+  case class Test(i: Int, s: String, j: Int)
+
+  "auto derivation for CsvRowDecoder" should "work properly for a simple case class (importing auto._)" in {
+    import auto._
+    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
+  }
+
+  it should "work properly for a simple case class (importing auto.csvrow._)" in {
+    import auto.csvrow._
+    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
+  }
+
+  it should "prefer custom decoders over derived ones" in {
+    import auto._
+    implicit val custom: CsvRowDecoder[Test, String] = _ => Right(Test(0, "", 0))
+    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(0, "", 0))
+  }
+
+  "auto derivation for RowDecoder" should "work properly for a simple case class (importing auto._)" in {
+    import auto._
+    RowDecoder[Test].apply(plainRow.values) shouldBe Right(Test(1, "test", 42))
+  }
+
+  it should "work properly for a simple case class (importing auto.csvrow._)" in {
+    import auto.row._
+    RowDecoder[Test].apply(plainRow.values) shouldBe Right(Test(1, "test", 42))
+  }
+
+  it should "prefer custom decoders over derived ones" in {
+    import auto._
+    implicit val custom: RowDecoder[Test] = _ => Right(Test(0, "", 0))
+    RowDecoder[Test].apply(plainRow.values) shouldBe Right(Test(0, "", 0))
+  }
+
+}

--- a/csv/src/fs2/data/csv/CsvRowDecoder.scala
+++ b/csv/src/fs2/data/csv/CsvRowDecoder.scala
@@ -26,7 +26,7 @@ trait CsvRowDecoder[T, Header] {
   def apply(row: CsvRow[Header]): DecoderResult[T]
 }
 
-object CsvRowDecoder {
+object CsvRowDecoder extends ExportedCsvRowDecoders {
 
   implicit def CsvRowDecoderMonadError[Header]: MonadError[CsvRowDecoder[*, Header], DecoderError] =
     new MonadError[CsvRowDecoder[*, Header], DecoderError] {
@@ -61,6 +61,10 @@ object CsvRowDecoder {
         T(row.values)
     }
 
-  def apply[Header, T: CsvRowDecoder[*, Header]]: CsvRowDecoder[T, Header] = implicitly[CsvRowDecoder[T, Header]]
+  def apply[T: CsvRowDecoder[*, Header], Header]: CsvRowDecoder[T, Header] = implicitly[CsvRowDecoder[T, Header]]
 
+}
+
+trait ExportedCsvRowDecoders {
+  implicit def exportedCsvRowDecoders[A](implicit exported: Exported[CsvRowDecoder[A, String]]): CsvRowDecoder[A, String] = exported.instance
 }

--- a/csv/src/fs2/data/csv/Exported.scala
+++ b/csv/src/fs2/data/csv/Exported.scala
@@ -1,0 +1,3 @@
+package fs2.data.csv
+
+case class Exported[A](instance: A) extends AnyVal

--- a/csv/src/fs2/data/csv/Exported.scala
+++ b/csv/src/fs2/data/csv/Exported.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package fs2.data.csv
 
 case class Exported[A](instance: A) extends AnyVal

--- a/csv/src/fs2/data/csv/RowDecoder.scala
+++ b/csv/src/fs2/data/csv/RowDecoder.scala
@@ -27,7 +27,7 @@ trait RowDecoder[T] {
   def apply(cells: NonEmptyList[String]): DecoderResult[T]
 }
 
-object RowDecoder {
+object RowDecoder extends ExportedRowDecoders {
 
   implicit object RowDecoderMonadError extends MonadError[RowDecoder, DecoderError] {
     def flatMap[A, B](fa: RowDecoder[A])(f: A => RowDecoder[B]): RowDecoder[B] =
@@ -57,4 +57,8 @@ object RowDecoder {
 
   def apply[T: RowDecoder]: RowDecoder[T] = implicitly[RowDecoder[T]]
 
+}
+
+trait ExportedRowDecoders {
+  implicit def exportedRowDecoders[A](implicit exported: Exported[RowDecoder[A]]): RowDecoder[A] = exported.instance
 }

--- a/csv/test/src/fs2/data/csv/CsvParserTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvParserTest.scala
@@ -46,8 +46,9 @@ class CsvParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     executor.shutdown()
   }
 
-  for (path <- File("csv/test/resources/csv-spectrum/csvs/").list) {
-    s"File ${path.toString}" should "be parsed correctly" in {
+  private val testFileDir: File = File("csv/test/resources/csv-spectrum/csvs/")
+  for (path <- testFileDir.list) {
+    s"File ${testFileDir.relativize(path).toString}" should "be parsed correctly" in {
       val expected =
         parse((File(s"csv/test/resources/csv-spectrum/json/${path.nameWithoutExtension}.json")).contentAsString)
           .flatMap(_.as[List[Map[String, String]]])

--- a/json/test/src/fs2/data/json/JsonParsertest.scala
+++ b/json/test/src/fs2/data/json/JsonParsertest.scala
@@ -54,8 +54,9 @@ class JsonParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
     executor.shutdown()
   }
 
-  for (path <- File("json/test/resources/test-parsing/").list) {
-    s"File ${path.toString}" should "be parsed correctly" in {
+  private val testFileDir: File = File("json/test/resources/test-parsing/")
+  for (path <- testFileDir.list) {
+    s"File ${testFileDir.relativize(path).toString}" should "be parsed correctly" in {
       val expectation =
         if (path.name.startsWith("y_"))
           Expectation.Valid

--- a/xml/test/src/fs2/data/xml/EventParserTest.scala
+++ b/xml/test/src/fs2/data/xml/EventParserTest.scala
@@ -44,10 +44,10 @@ class EventParserTest extends FlatSpec with Matchers with EitherValues with Befo
     executor.shutdown()
   }
 
+  val testFileDir = File("xml/test/resources/xmlconf")
   // valid tests
-  for (path <- File("xml/test/resources/xmlconf/xmltest/valid/").list(_.name.endsWith(".xml")) ++ File(
-         "xml/test/resources/xmlconf/sun/valid/").list) {
-    s"File ${path.toString}" should "be parsed correctly" in {
+  for (path <- File(testFileDir, "xmltest/valid/").list(_.name.endsWith(".xml")) ++ File(testFileDir, "sun/valid/").list) {
+    s"File ${testFileDir.relativize(path).toString}" should "be parsed correctly" in {
       file
         .readAll[IO](path.path, blocker, 1024)
         .through(fs2.text.utf8Decode)


### PR DESCRIPTION
Using the same technique as in pureconfig and circe. Once #10 is merged, support for cell decoders can be added as well.

Additionally, I added a small beautification to the file-based tests, relativizing the file paths to make the test output more readable.