### PR TITLE
Allow usage of CsvName to rename fields in CsvRowDecoder derivation

### DIFF
--- a/csv/generic/src/fs2/data/csv/generic/CsvName.scala
+++ b/csv/generic/src/fs2/data/csv/generic/CsvName.scala
@@ -1,0 +1,9 @@
+package fs2.data.csv.generic
+
+import scala.annotation.Annotation
+
+/**
+ * Mark a field of a case class to have a different name in the CSV when deriving a codec.
+ * @param name the name to expect in the CSV
+ */
+case class CsvName(name: String) extends Annotation

--- a/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
@@ -24,14 +24,15 @@ trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, String]
 
 object DerivedCsvRowDecoder {
 
-  final implicit def productReader[T, Repr <: HList, DefaultRepr <: HList](
+  final implicit def productReader[T, Repr <: HList, DefaultRepr <: HList, AnnoRepr <: HList](
       implicit
       gen: LabelledGeneric.Aux[T, Repr],
       defaults: Default.AsOptions.Aux[T, DefaultRepr],
-      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr]]): DerivedCsvRowDecoder[T] =
+      annotations: Annotations.Aux[CsvName, T, AnnoRepr],
+      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
     new DerivedCsvRowDecoder[T] {
       def apply(row: CsvRow[String]): DecoderResult[T] =
-        cc.value.fromWithDefault(row, defaults()).map(gen.from(_))
+        cc.value.fromWithDefault(row, defaults(), annotations()).map(gen.from(_))
     }
 
 }

--- a/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowDecoder.scala
@@ -27,27 +27,29 @@ trait MapShapedCsvRowDecoder[Repr] extends CsvRowDecoder[Repr, String]
 
 object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
 
-  implicit def hnilRowDecoder[Wrapped]: WithDefaults[Wrapped, HNil, HNil] = new WithDefaults[Wrapped, HNil, HNil] {
-    def fromWithDefault(row: CsvRow[String], default: HNil): DecoderResult[HNil] =
+  implicit def hnilRowDecoder[Wrapped]: WithDefaults[Wrapped, HNil, HNil, HNil] = new WithDefaults[Wrapped, HNil, HNil, HNil] {
+    def fromWithDefault(row: CsvRow[String], default: HNil, annotation: HNil): DecoderResult[HNil] =
       Right(HNil)
   }
 
-  implicit def optionHconsRowDecoder[Wrapped, Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList](
+  implicit def optionHconsRowDecoder[Wrapped, Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
       implicit witness: Witness.Aux[Key],
       Head: CellDecoder[Head],
-      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail]])
-      : WithDefaults[Wrapped, FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail] =
-    new WithDefaults[Wrapped, FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail] {
+      ev: <:<[Anno, Option[CsvName]],
+      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail, AnnoTail]])
+      : WithDefaults[Wrapped, FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail, Anno :: AnnoTail] =
+    new WithDefaults[Wrapped, FieldType[Key, Option[Head]] :: Tail, Option[Option[Head]] :: DefaultTail, Anno :: AnnoTail] {
       def fromWithDefault(
           row: CsvRow[String],
-          default: Option[Option[Head]] :: DefaultTail): DecoderResult[FieldType[Key, Option[Head]] :: Tail] = {
+          default: Option[Option[Head]] :: DefaultTail,
+          anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Option[Head]] :: Tail] = {
         val head = row(witness.value.name) match {
           case Some(head) if head.nonEmpty => Head(head).map(Some(_))
           case _                           => Right(default.head.flatten)
         }
         for {
           head <- head
-          tail <- Tail.value.fromWithDefault(row, default.tail)
+          tail <- Tail.value.fromWithDefault(row, default.tail, anno.tail)
         } yield field[Key](head) :: tail
       }
     }
@@ -56,19 +58,20 @@ object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
 
 trait LowPriorityMapShapedCsvRowDecoder1 {
 
-  trait WithDefaults[Wrapped, Repr, DefaultRepr] {
-    def fromWithDefault(row: CsvRow[String], default: DefaultRepr): DecoderResult[Repr]
+  trait WithDefaults[Wrapped, Repr, DefaultRepr, AnnoRepr] {
+    def fromWithDefault(row: CsvRow[String], default: DefaultRepr, annotation: AnnoRepr): DecoderResult[Repr]
   }
 
-  implicit def hconsRowDecoder[Wrapped, Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList](
+  implicit def hconsRowDecoder[Wrapped, Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
       implicit witness: Witness.Aux[Key],
       Head: CellDecoder[Head],
-      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail]])
-      : WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail] =
-    new WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail] {
+      ev: <:<[Anno, Option[CsvName]],
+      Tail: Lazy[WithDefaults[Wrapped, Tail, DefaultTail, AnnoTail]])
+      : WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] =
+    new WithDefaults[Wrapped, FieldType[Key, Head] :: Tail, Option[Head] :: DefaultTail, Anno :: AnnoTail] {
       def fromWithDefault(row: CsvRow[String],
-                          default: Option[Head] :: DefaultTail): DecoderResult[FieldType[Key, Head] :: Tail] = {
-        val head = row(witness.value.name) match {
+                          default: Option[Head] :: DefaultTail, anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Head] :: Tail] = {
+        val head = row(anno.head.fold(witness.value.name)(_.name)) match {
           case Some(head) if head.nonEmpty =>
             Head(head)
           case _ =>
@@ -76,7 +79,7 @@ trait LowPriorityMapShapedCsvRowDecoder1 {
         }
         for {
           head <- head
-          tail <- Tail.value.fromWithDefault(row, default.tail)
+          tail <- Tail.value.fromWithDefault(row, default.tail, anno.tail)
         } yield field[Key](head) :: tail
       }
     }

--- a/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CellDecoderTest.scala
@@ -48,7 +48,7 @@ class CellDecoderTest extends FlatSpec with Matchers with EitherValues {
     complexDecoder("foo") shouldBe Right(Unknown("foo"))
   }
 
-  it should "respect @CsvName annotations" in {
+  it should "respect @CsvValue annotations" in {
     val alphabetDecoder: CellDecoder[Alphabet] = semiauto.deriveCellDecoder
 
     Annotation[CsvValue, Alpha.type].apply().value shouldBe "A"

--- a/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
@@ -33,9 +33,11 @@ class CsvRowDecoderTest extends FlatSpec with Matchers {
 
   case class Test(i: Int = 0, s: String, j: Option[Int])
   case class TestOrder(s: String, j: Int, i: Int)
+  case class TestRename(s: String, @CsvName("j") k: Int, i: Int)
 
   val testDecoder = deriveCsvRowDecoder[Test]
   val testOrderDecoder = deriveCsvRowDecoder[TestOrder]
+  val testRenameDecoder = deriveCsvRowDecoder[TestRename]
 
   "case classes" should "be decoded properly by header name and not position" in {
     testDecoder(csvRow) shouldBe Right(Test(1, "test", Some(42)))
@@ -57,6 +59,10 @@ class CsvRowDecoderTest extends FlatSpec with Matchers {
 
   it should "be handled properly with optional value and missing column" in {
     testDecoder(csvRowNoJ) shouldBe Right(Test(1, "test", None))
+  }
+
+  it should "be decoded according to their field renames" in {
+    testRenameDecoder(csvRow) shouldBe Right(TestRename("test", 42, 1))
   }
 
 }


### PR DESCRIPTION
For cases where your header name in the CSV file differs from the field name in your case class. See test for an example.