### PR TITLE
Generalize header parsing

### DIFF
--- a/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
@@ -18,10 +18,9 @@ package data
 package csv
 package generic
 
-import cats.data.NonEmptyList
 import shapeless._
 
-trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, NonEmptyList[String]]
+trait DerivedCsvRowDecoder[T] extends CsvNelRowDecoder[T, String]
 
 object DerivedCsvRowDecoder {
 

--- a/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
@@ -18,9 +18,10 @@ package data
 package csv
 package generic
 
+import cats.data.NonEmptyList
 import shapeless._
 
-trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, String]
+trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, NonEmptyList[String]]
 
 object DerivedCsvRowDecoder {
 
@@ -31,7 +32,7 @@ object DerivedCsvRowDecoder {
       annotations: Annotations.Aux[CsvName, T, AnnoRepr],
       cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
     new DerivedCsvRowDecoder[T] {
-      def apply(row: CsvRow[String]): DecoderResult[T] =
+      def apply(row: CsvNelRow[String]): DecoderResult[T] =
         cc.value.fromWithDefault(row, defaults(), annotations()).map(gen.from(_))
     }
 

--- a/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
+++ b/csv/generic/src/fs2/data/csv/generic/ExportMacros.scala
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fs2.data.csv.generic
-
-import fs2.data.csv.{CellDecoder, CsvRowDecoder, Exported, RowDecoder}
+package fs2.data.csv
+package generic
 
 import scala.reflect.macros.blackbox
 
@@ -34,12 +33,12 @@ class ExportMacros(val c: blackbox.Context) {
     }
   }
 
-  final def exportCsvRowDecoder[A](implicit a: c.WeakTypeTag[A]): c.Expr[Exported[CsvRowDecoder[A, String]]] = {
+  final def exportCsvRowDecoder[A](implicit a: c.WeakTypeTag[A]): c.Expr[Exported[CsvNelRowDecoder[A, String]]] = {
     c.typecheck(q"_root_.shapeless.lazily[_root_.fs2.data.csv.generic.DerivedCsvRowDecoder[$a]]", silent = true) match {
       case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type $a")
       case t =>
-        c.Expr[Exported[CsvRowDecoder[A, String]]](
-          q"new _root_.fs2.data.csv.Exported($t: _root_.fs2.data.csv.CsvRowDecoder[$a, ${weakTypeTag[String]}])")
+        c.Expr[Exported[CsvNelRowDecoder[A, String]]](
+          q"new _root_.fs2.data.csv.Exported($t: _root_.fs2.data.csv.CsvNelRowDecoder[$a, ${weakTypeTag[String]}])")
     }
   }
 

--- a/csv/generic/src/fs2/data/csv/generic/auto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/auto.scala
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fs2.data.csv.generic
+package fs2.data.csv
+package generic
 
-import fs2.data.csv.{CellDecoder, CsvRowDecoder, Exported, RowDecoder}
 
 import scala.language.experimental.macros
 
@@ -24,7 +24,7 @@ trait AutoDerivedRowDecoders {
 }
 
 trait AutoDerivedCsvRowDecoders {
-  implicit def exportCsvRowDecoder[A]: Exported[CsvRowDecoder[A, String]] = macro ExportMacros.exportCsvRowDecoder[A]
+  implicit def exportCsvRowDecoder[A]: Exported[CsvNelRowDecoder[A, String]] = macro ExportMacros.exportCsvRowDecoder[A]
 }
 
 trait AutoDerivedCellDecoders {

--- a/csv/generic/src/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/semiauto.scala
@@ -18,7 +18,6 @@ package data
 package csv
 package generic
 
-import cats.data.NonEmptyList
 import shapeless._
 
 object semiauto {
@@ -26,7 +25,7 @@ object semiauto {
   def deriveRowDecoder[T](implicit T: Lazy[DerivedRowDecoder[T]]): RowDecoder[T] =
     T.value
 
-  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, NonEmptyList[String]] =
+  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvNelRowDecoder[T, String] =
     T.value
 
   def deriveCellDecoder[T](implicit T: Lazy[DerivedCellDecoder[T]]): CellDecoder[T] =

--- a/csv/generic/src/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/src/fs2/data/csv/generic/semiauto.scala
@@ -18,6 +18,7 @@ package data
 package csv
 package generic
 
+import cats.data.NonEmptyList
 import shapeless._
 
 object semiauto {
@@ -25,7 +26,7 @@ object semiauto {
   def deriveRowDecoder[T](implicit T: Lazy[DerivedRowDecoder[T]]): RowDecoder[T] =
     T.value
 
-  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, String] =
+  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, NonEmptyList[String]] =
     T.value
 
   def deriveCellDecoder[T](implicit T: Lazy[DerivedCellDecoder[T]]): CellDecoder[T] =

--- a/csv/generic/test/src/fs2/data/csv/generic/AutoDerivationTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/AutoDerivationTest.scala
@@ -16,7 +16,7 @@
 package fs2.data.csv.generic
 
 import cats.data.NonEmptyList
-import fs2.data.csv.{CellDecoder, CsvRow, CsvRowDecoder, RowDecoder}
+import fs2.data.csv.{CellDecoder, CsvNelRowDecoder, CsvRow, RowDecoder}
 import org.scalatest._
 
 class AutoDerivationTest extends FlatSpec with Matchers {
@@ -32,18 +32,17 @@ class AutoDerivationTest extends FlatSpec with Matchers {
 
   "auto derivation for CsvRowDecoder" should "work properly for a simple case class (importing auto._)" in {
     import auto._
-    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
+    CsvNelRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
   }
 
   it should "work properly for a simple case class (importing auto.csvrow._)" in {
     import auto.csvrow._
-    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
+    CsvNelRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(1, "test", 42))
   }
 
   it should "prefer custom decoders over derived ones" in {
-    import auto._
-    implicit val custom: CsvRowDecoder[Test, String] = _ => Right(Test(0, "", 0))
-    CsvRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(0, "", 0))
+    implicit val custom: CsvNelRowDecoder[Test, String] = _ => Right(Test(0, "", 0))
+    CsvNelRowDecoder[Test, String].apply(csvRow) shouldBe Right(Test(0, "", 0))
   }
 
   "auto derivation for RowDecoder" should "work properly for a simple case class (importing auto._)" in {
@@ -57,7 +56,6 @@ class AutoDerivationTest extends FlatSpec with Matchers {
   }
 
   it should "prefer custom decoders over derived ones" in {
-    import auto._
     implicit val custom: RowDecoder[Test] = _ => Right(Test(0, "", 0))
     RowDecoder[Test].apply(plainRow.values) shouldBe Right(Test(0, "", 0))
   }

--- a/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
@@ -25,11 +25,11 @@ import cats.data.NonEmptyList
 
 class CsvRowDecoderTest extends FlatSpec with Matchers {
 
-  val csvRow = new CsvRow(NonEmptyList.of("1", "test", "42"), Some(NonEmptyList.of("i", "s", "j")))
-  val csvRowDefaultI = new CsvRow(NonEmptyList.of("", "test", "42"), Some(NonEmptyList.of("i", "s", "j")))
-  val csvRowNoI = new CsvRow(NonEmptyList.of("test", "42"), Some(NonEmptyList.of("s", "j")))
-  val csvRowEmptyJ = new CsvRow(NonEmptyList.of("1", "test", ""), Some(NonEmptyList.of("i", "s", "j")))
-  val csvRowNoJ = new CsvRow(NonEmptyList.of("1", "test"), Some(NonEmptyList.of("i", "s")))
+  val csvRow = CsvRow(NonEmptyList.of("1", "test", "42"), Some(NonEmptyList.of("i", "s", "j")))
+  val csvRowDefaultI = CsvRow(NonEmptyList.of("", "test", "42"), Some(NonEmptyList.of("i", "s", "j")))
+  val csvRowNoI = CsvRow(NonEmptyList.of("test", "42"), Some(NonEmptyList.of("s", "j")))
+  val csvRowEmptyJ = CsvRow(NonEmptyList.of("1", "test", ""), Some(NonEmptyList.of("i", "s", "j")))
+  val csvRowNoJ = CsvRow(NonEmptyList.of("1", "test"), Some(NonEmptyList.of("i", "s")))
 
   case class Test(i: Int = 0, s: String, j: Option[Int])
   case class TestOrder(s: String, j: Int, i: Int)

--- a/csv/src/fs2/data/csv/CsvRow.scala
+++ b/csv/src/fs2/data/csv/CsvRow.scala
@@ -18,10 +18,7 @@ package fs2.data.csv
 import cats.data._
 import cats.implicits._
 
-case class CsvRow[Header](values: NonEmptyList[String], header: Option[Header]) {
-
-  private def byHeader[A](implicit ev: Header =:= NonEmptyList[A]): Option[Map[A, String]] =
-    header.map(_.toList.zip(values.toList).toMap)
+case class CsvRow[Header] private[csv] (values: NonEmptyList[String], header: Option[Header]) {
 
   /** Number of cells in the row. */
   def size: Int = values.size
@@ -47,18 +44,6 @@ case class CsvRow[Header](values: NonEmptyList[String], header: Option[Header]) 
             cell
       }, header)
 
-  /** Modifies the cell content at the given `header` using the function `f`.
-    *
-    * **Note:** Only the first occurrence of the values with the given header
-    * will be modified. It shouldn't be a problem in the general case as headers
-    * should not be duplicated.
-    */
-  def modify[A](head: A)(f: String => String)(implicit ev: Header =:= NonEmptyList[A]): CsvRow[Header] =
-    header match {
-      case Some(header) => modify(header.toList.indexOf(head))(f)
-      case None          => this
-    }
-
   /** Returns the row with the cell at `idx` modifed to `value`. */
   def updated(idx: Int, value: String): CsvRow[Header] =
     if (idx < 0 || idx >= values.size)
@@ -71,61 +56,6 @@ case class CsvRow[Header](values: NonEmptyList[String], header: Option[Header]) 
           else
             cell
       }, header)
-
-  /** Returns the row with the cell at `header` modifed to `value`.
-    *
-    * **Note:** Only the first occurrence of the values with the given header
-    * will be modified. It shouldn't be a problem in the general case as headers
-    * should not be duplicated.
-    */
-  def updated[A](head: Header, value: String)(implicit ev: Header =:= NonEmptyList[A]): CsvRow[Header] =
-    header match {
-      case Some(headers) => updated(headers.toList.indexOf(head), value)
-      case None          => this
-    }
-
-  /** Returns the row without the cell at the given `idx`.
-    * If the resulting row is empty, returns `None`.
-    */
-  def delete[A](idx: Int)(implicit ev: Header =:= NonEmptyList[A]): Option[CsvRow[NonEmptyList[A]]] =
-    if (idx < 0 || idx >= values.size) {
-      Some(this.asInstanceOf[CsvRow[NonEmptyList[A]]])
-    } else {
-      val (before, after) = values.toList.splitAt(idx)
-      val newHeaders = header match {
-        case None => Nil
-        case _ =>
-          val (h1, h2) = header.fold[List[A]](Nil)(_.toList).splitAt(idx)
-          h1 ++ h2.tail
-      }
-      NonEmptyList.fromList(before ++ after.tail).map(new CsvRow(_, NonEmptyList.fromList(newHeaders)))
-    }
-
-  /** Returns the row without the cell at the given `header`.
-    * If the resulting row is empty, returns `None`.
-    *
-    * **Note:** Only the first occurrence of the values with the given header
-    * will be deleted. It shouldn't be a problem in the general case as headers
-    * should not be duplicated.
-    */
-  def delete[A](head: A)(implicit ev: Header =:= NonEmptyList[A]): Option[CsvRow[NonEmptyList[A]]] =
-    header match {
-      case Some(headers) => delete(headers.toList.indexOf(head))
-      case None          => Some(this.asInstanceOf[CsvRow[NonEmptyList[A]]])
-    }
-
-  /** Returns the content of the cell at `headers` if it exists.
-    * Returns `None` if `header` does not exist for the row.
-    * An empty cell value results in `Some("")`.
-    */
-  def apply[A](head: A)(implicit ev: Header =:= NonEmptyList[A]): Option[String] =
-    byHeader.flatMap(_.get(head))
-
-  /** Returns a map representation of this row if headers are defined, otherwise
-    * returns `None`.
-    */
-  def toMap[A](implicit ev: Header =:= NonEmptyList[A]): Option[Map[A, String]] =
-    byHeader
 
 }
 
@@ -140,18 +70,89 @@ object CsvRow {
   def fromListAndHeader[Header](l: List[String], header: Header): Option[CsvRow[Header]] =
     NonEmptyList.fromList(l).map(CsvRow(_, Some(header)))
 
-  // this is almost only an alias for apply, here for consistency with fromListAndHeader
   def fromNelAndHeader[Header](nel: NonEmptyList[String], header: Header): CsvRow[Header] =
     CsvRow(nel, Some(header))
 
-  def fromListHeaders[HeadElem](l: List[(HeadElem, String)]): Option[CsvRow[NonEmptyList[HeadElem]]] = {
+  def fromListHeaders[HeadElem](l: List[(HeadElem, String)]): Option[CsvNelRow[HeadElem]] = {
     val (hs, vs) = l.unzip
     NonEmptyList.fromList(vs).map(CsvRow(_, NonEmptyList.fromList(hs)))
   }
 
-  def fromNelHeaders[HeadElem](nel: NonEmptyList[(HeadElem, String)]): CsvRow[NonEmptyList[HeadElem]] = {
+  def fromNelHeaders[HeadElem](nel: NonEmptyList[(HeadElem, String)]): CsvNelRow[HeadElem] = {
     val (hs, vs) = nel.toList.unzip
     CsvRow(NonEmptyList.fromListUnsafe(vs), NonEmptyList.fromList(hs))
+  }
+
+  implicit class CsvRowNelOps[HeadElem](row: CsvNelRow[HeadElem]) {
+    private def byHeader: Option[Map[HeadElem, String]] =
+      row.header.map(_.toList.zip(row.values.toList).toMap)
+
+    /** Modifies the cell content at the given `header` using the function `f`.
+     *
+     * **Note:** Only the first occurrence of the values with the given header
+     * will be modified. It shouldn't be a problem in the general case as headers
+     * should not be duplicated.
+     */
+    def modify(head: HeadElem)(f: String => String): CsvNelRow[HeadElem] =
+      row.header match {
+        case Some(header) => row.modify(header.toList.indexOf(head))(f)
+        case None         => row
+      }
+
+    /** Returns the row with the cell at `header` modified to `value`.
+     *
+     * **Note:** Only the first occurrence of the values with the given header
+     * will be modified. It shouldn't be a problem in the general case as headers
+     * should not be duplicated.
+     */
+    def updated(head: HeadElem, value: String): CsvNelRow[HeadElem] =
+      row.header match {
+        case Some(headers) => row.updated(headers.toList.indexOf(head), value)
+        case None          => row
+      }
+
+    /** Returns the row without the cell at the given `idx`.
+     * If the resulting row is empty, returns `None`.
+     */
+    def delete(idx: Int): Option[CsvNelRow[HeadElem]] =
+      if (idx < 0 || idx >= row.values.size) {
+        Some(row)
+      } else {
+        val (before, after) = row.values.toList.splitAt(idx)
+        val newHeaders = row.header match {
+          case None => Nil
+          case _ =>
+            val (h1, h2) = row.header.fold[List[HeadElem]](Nil)(_.toList).splitAt(idx)
+            h1 ++ h2.tail
+        }
+        NonEmptyList.fromList(before ++ after.tail).map(new CsvRow(_, NonEmptyList.fromList(newHeaders)))
+      }
+
+    /** Returns the row without the cell at the given `header`.
+     * If the resulting row is empty, returns `None`.
+     *
+     * **Note:** Only the first occurrence of the values with the given header
+     * will be deleted. It shouldn't be a problem in the general case as headers
+     * should not be duplicated.
+     */
+    def delete(head: HeadElem): Option[CsvNelRow[HeadElem]] =
+      row.header match {
+        case Some(headers) => delete(headers.toList.indexOf(head))
+        case None          => Some(this.asInstanceOf[CsvNelRow[HeadElem]])
+      }
+
+    /** Returns the content of the cell at `headers` if it exists.
+     * Returns `None` if `header` does not exist for the row.
+     * An empty cell value results in `Some("")`.
+     */
+    def apply(head: HeadElem): Option[String] =
+      byHeader.flatMap(_.get(head))
+
+    /** Returns a map representation of this row if headers are defined, otherwise
+     * returns `None`.
+     */
+    def toMap: Option[Map[HeadElem, String]] =
+      byHeader
   }
 
 }

--- a/csv/src/fs2/data/csv/CsvRow.scala
+++ b/csv/src/fs2/data/csv/CsvRow.scala
@@ -18,7 +18,7 @@ package fs2.data.csv
 import cats.data._
 import cats.implicits._
 
-class CsvRow[Header](val values: NonEmptyList[String], val headers: Option[NonEmptyList[Header]]) {
+case class CsvRow[Header](values: NonEmptyList[String], headers: Option[NonEmptyList[Header]]) {
 
   private lazy val byHeader: Option[Map[Header, String]] =
     headers.map(_.toList.zip(values.toList).toMap)

--- a/csv/src/fs2/data/csv/CsvRowDecoder.scala
+++ b/csv/src/fs2/data/csv/CsvRowDecoder.scala
@@ -71,5 +71,5 @@ object CsvRowDecoder extends ExportedCsvRowDecoders {
 }
 
 trait ExportedCsvRowDecoders {
-  implicit def exportedCsvRowDecoders[A](implicit exported: Exported[CsvRowDecoder[A, String]]): CsvRowDecoder[A, String] = exported.instance
+  implicit def exportedCsvRowDecoders[A](implicit exported: Exported[CsvNelRowDecoder[A, String]]): CsvNelRowDecoder[A, String] = exported.instance
 }

--- a/csv/src/fs2/data/csv/CsvRowDecoder.scala
+++ b/csv/src/fs2/data/csv/CsvRowDecoder.scala
@@ -16,6 +16,7 @@
 package fs2.data.csv
 
 import cats._
+import cats.data.NonEmptyList
 import cats.implicits._
 
 import scala.annotation.tailrec
@@ -62,6 +63,10 @@ object CsvRowDecoder extends ExportedCsvRowDecoders {
     }
 
   def apply[T: CsvRowDecoder[*, Header], Header]: CsvRowDecoder[T, Header] = implicitly[CsvRowDecoder[T, Header]]
+
+  def fromNonEmptyHeader[Header, T](decode: (NonEmptyList[String], Header) => DecoderResult[T]): CsvRowDecoder[T, Header] =
+    (row: CsvRow[Header]) => row.header.toRight(new DecoderError("This decoder requires the header to be parsed"))
+      .flatMap(decode(row.values, _))
 
 }
 

--- a/csv/src/fs2/data/csv/ParseableHeader.scala
+++ b/csv/src/fs2/data/csv/ParseableHeader.scala
@@ -35,18 +35,18 @@ object ParseableHeader {
   def apply[Header: ParseableHeader]: ParseableHeader[Header] =
     implicitly[ParseableHeader[Header]]
 
-  def parseIndependently[HeadElem](parse: String => HeaderResult[HeadElem]): ParseableHeader[NonEmptyList[HeadElem]] =
+  def parseNel[HeadElem](parse: String => HeaderResult[HeadElem]): ParseableNelHeader[HeadElem] =
     (names: NonEmptyList[String]) => names.traverse(parse)
 
   implicit object NothingParseableHeader extends ParseableHeader[Nothing] {
     def apply(names: NonEmptyList[String]): HeaderResult[Nothing] = new HeaderError("no headers are expected").asLeft
   }
 
-  implicit object StringNelParseableHeader extends ParseableHeader[NonEmptyList[String]] {
+  implicit object StringNelParseableHeader extends ParseableNelHeader[String] {
     def apply(names: NonEmptyList[String]): HeaderResult[NonEmptyList[String]] = names.asRight
   }
 
-  implicit object NonEmptyStringNelParseableHeader extends ParseableHeader[NonEmptyList[Option[String]]] {
+  implicit object NonEmptyStringNelParseableHeader extends ParseableNelHeader[Option[String]] {
     def apply(names: NonEmptyList[String]): HeaderResult[NonEmptyList[Option[String]]] = names.map { name =>
       if (name.isEmpty)
         none

--- a/csv/src/fs2/data/csv/ParseableHeader.scala
+++ b/csv/src/fs2/data/csv/ParseableHeader.scala
@@ -15,12 +15,17 @@
  */
 package fs2.data.csv
 
-/** A typeclass describing what it means to be a parseable
+import cats.{MonadError, SemigroupK}
+import cats.implicits._
+
+import scala.annotation.tailrec
+
+/** A type class describing what it means to be a parseable
   * CSV header.
   */
 trait ParseableHeader[Header] {
 
-  def parse(name: String): Header
+  def apply(name: String): DecoderResult[Header]
 
 }
 
@@ -30,19 +35,50 @@ object ParseableHeader {
     implicitly[ParseableHeader[Header]]
 
   implicit object NothingParseableHeader extends ParseableHeader[Nothing] {
-    def parse(name: String): Nothing = throw new CsvException("no headers are expected")
+    def apply(name: String): DecoderResult[Nothing] = new DecoderError("no headers are expected").asLeft
   }
 
   implicit object StringParseableHeader extends ParseableHeader[String] {
-    def parse(name: String) = name
+    def apply(name: String): DecoderResult[String] = name.asRight
   }
 
   implicit object NonEmptyStringParseableHeader extends ParseableHeader[Option[String]] {
-    def parse(name: String) =
+    def apply(name: String): DecoderResult[Option[String]] =
       if (name.isEmpty)
-        None
+        none.asRight
       else
-        Some(name)
+        name.some.asRight
+  }
+
+  implicit object ParseableHeaderInstances extends MonadError[ParseableHeader, DecoderError] with SemigroupK[ParseableHeader] {
+    def flatMap[A, B](fa: ParseableHeader[A])(f: A => ParseableHeader[B]): ParseableHeader[B] =
+      s => fa(s).flatMap(f(_)(s))
+
+    def handleErrorWith[A](fa: ParseableHeader[A])(f: DecoderError => ParseableHeader[A]): ParseableHeader[A] =
+      s => fa(s).leftFlatMap(f(_)(s))
+
+    def pure[A](x: A): ParseableHeader[A] =
+      _ => Right(x)
+
+    def raiseError[A](e: DecoderError): ParseableHeader[A] =
+      _ => Left(e)
+
+    def tailRecM[A, B](a: A)(f: A => ParseableHeader[Either[A, B]]): ParseableHeader[B] = {
+      @tailrec
+      def step(s: String, a: A): DecoderResult[B] =
+        f(a)(s) match {
+          case left @ Left(_)          => left.rightCast[B]
+          case Right(Left(a))          => step(s, a)
+          case Right(right @ Right(_)) => right.leftCast[DecoderError]
+        }
+      s => step(s, a)
+    }
+
+    override def combineK[A](x: ParseableHeader[A], y: ParseableHeader[A]): ParseableHeader[A] = s =>
+      x(s) match {
+        case Left(_)      => y(s)
+        case r @ Right(_) => r
+      }
   }
 
 }

--- a/csv/src/fs2/data/csv/exceptions.scala
+++ b/csv/src/fs2/data/csv/exceptions.scala
@@ -18,3 +18,5 @@ package fs2.data.csv
 class CsvException(msg: String, inner: Throwable = null) extends Exception(msg, inner)
 
 class DecoderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)
+
+class HeaderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)

--- a/csv/src/fs2/data/csv/internals/CsvRowParser.scala
+++ b/csv/src/fs2/data/csv/internals/CsvRowParser.scala
@@ -32,8 +32,7 @@ private[csv] object CsvRowParser {
     _.evalMapAccumulate[F, Headers[Header], Option[CsvRow[Header]]](Headers.Uninitialized[Header]()) {
       case (Headers.Uninitialized(), fields) if withHeaders =>
         // headers have not been seen yet (first row)
-        val headerResult = fields.traverse(Header.apply)
-        F.fromEither(headerResult).map { headers =>
+        F.fromEither(Header(fields)).map { headers =>
           Headers.Initialized(Some(headers)) ->  None
         }
       case (Headers.Uninitialized(), fields) =>

--- a/csv/src/fs2/data/csv/internals/Headers.scala
+++ b/csv/src/fs2/data/csv/internals/Headers.scala
@@ -18,14 +18,12 @@ package data
 package csv
 package internals
 
-import cats.data._
-
 private sealed trait Headers[Header]
 
 private[internals] object Headers {
 
   case class Uninitialized[Header]() extends Headers[Header]
 
-  case class Initialized[Header](headers: Option[NonEmptyList[Header]]) extends Headers[Header]
+  case class Initialized[Header](headers: Option[Header]) extends Headers[Header]
 
 }

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -19,7 +19,6 @@ package data
 import java.nio.{CharBuffer => JCharBuffer}
 
 import csv.internals._
-
 import cats._
 import cats.data._
 import cats.implicits._
@@ -34,7 +33,17 @@ package object csv {
 
   type CsvNelRow[HeadElem] = CsvRow[NonEmptyList[HeadElem]]
 
+  type CsvNelRowDecoder[T, HeadElem] = CsvRowDecoder[T, NonEmptyList[HeadElem]]
+
+  object CsvNelRowDecoder {
+    def apply[T, HeadElem](implicit dec: CsvNelRowDecoder[T, HeadElem]): CsvNelRowDecoder[T, HeadElem] = dec
+  }
+
   type ParseableNelHeader[HeadElem] = ParseableHeader[NonEmptyList[HeadElem]]
+
+  object ParseableNelHeader {
+    def apply[HeadElem](implicit dec: ParseableNelHeader[HeadElem]): ParseableNelHeader[HeadElem] = dec
+  }
 
   /** Transforms a stream of characters into a stream of CSV rows.
     */

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -34,6 +34,8 @@ package object csv {
 
   type CsvNelRow[HeadElem] = CsvRow[NonEmptyList[HeadElem]]
 
+  type ParseableNelHeader[HeadElem] = ParseableHeader[NonEmptyList[HeadElem]]
+
   /** Transforms a stream of characters into a stream of CSV rows.
     */
   def rows[F[_]](separator: Char = ',')(
@@ -54,7 +56,7 @@ package object csv {
 
   /** Transforms a stream of raw CSV rows into parsed CSV rows with a NonEmptyList of independent headers. */
   def nelHeaders[F[_], HeadElem](implicit F: ApplicativeError[F, Throwable],
-                                 Header: ParseableHeader[NonEmptyList[HeadElem]]): Pipe[F, NonEmptyList[String], CsvNelRow[HeadElem]] =
+                                 Header: ParseableNelHeader[HeadElem]): Pipe[F, NonEmptyList[String], CsvNelRow[HeadElem]] =
     CsvRowParser.pipe[F, NonEmptyList[HeadElem]](true)
 
   /** Transforms a stream of raw CSV rows into parsed CSV rows with headers. */

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -39,6 +39,11 @@ package object csv {
                             Header: ParseableHeader[Header]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
     CsvRowParser.pipe[F, Header](true)
 
+  /** Transforms a stream of raw CSV rows into parsed CSV rows with a NonEmptyList of independent headers. */
+  def headerNel[F[_], HeadElem](implicit F: ApplicativeError[F, Throwable],
+                            Header: ParseableHeader[NonEmptyList[HeadElem]]): Pipe[F, NonEmptyList[String], CsvRow[NonEmptyList[HeadElem]]] =
+    CsvRowParser.pipe[F, NonEmptyList[HeadElem]](true)
+
   /** Transforms a stream of raw CSV rows into parsed CSV rows with headers. */
   def noHeaders[F[_]](implicit F: ApplicativeError[F, Throwable]): Pipe[F, NonEmptyList[String], CsvRow[Nothing]] =
     CsvRowParser.pipe[F, Nothing](false)

--- a/csv/test/src/fs2/data/csv/CsvParserTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvParserTest.scala
@@ -20,7 +20,6 @@ import java.util.concurrent._
 import better.files.{Resource => _, _}
 import cats.effect._
 import io.circe.parser._
-import fs2._
 import fs2.io._
 import org.scalatest._
 
@@ -54,9 +53,8 @@ class CsvParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
         file
           .readAll[IO](path.path, blocker, 1024)
           .through(fs2.text.utf8Decode)
-          .flatMap(Stream.emits(_))
-          .through(rows[IO]())
-          .through(headerNel[IO, String])
+          .through(rowsFromStrings[IO]())
+          .through(nelHeaders[IO, String])
           .compile
           .toList
           .unsafeRunSync()

--- a/csv/test/src/fs2/data/csv/CsvParserTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvParserTest.scala
@@ -15,20 +15,16 @@
  */
 package fs2.data.csv
 
-import io.circe.parser._
+import java.util.concurrent._
 
+import better.files.{Resource => _, _}
+import cats.effect._
+import io.circe.parser._
 import fs2._
 import fs2.io._
-
-import cats.effect._
-
 import org.scalatest._
 
 import scala.concurrent._
-
-import better.files.{Resource => _, _}
-
-import java.util.concurrent._
 
 class CsvParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
@@ -60,7 +56,7 @@ class CsvParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
           .through(fs2.text.utf8Decode)
           .flatMap(Stream.emits(_))
           .through(rows[IO]())
-          .through(headers[IO, String])
+          .through(headerNel[IO, String])
           .compile
           .toList
           .unsafeRunSync()

--- a/csv/test/src/fs2/data/csv/CsvRowTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvRowTest.scala
@@ -1,0 +1,31 @@
+package fs2.data.csv
+
+import cats.data.NonEmptyList
+import org.scalatest.{FlatSpec, Matchers}
+
+class CsvRowTest extends FlatSpec with Matchers {
+
+  "CsvRow" should "allow simple operations for any Header type" in {
+    // Unit is a good placeholder for some opaque user type
+    val testRow = CsvRow.fromNelAndHeader(NonEmptyList.of("1", "3", "5"), ())
+    testRow.size should be(3)
+    testRow(2) should contain ("5")
+    val modified = testRow.modify(2)(_ * 2)
+    modified(2) should contain ("55")
+    val updated = testRow.updated(1, "9")
+    updated(1) should contain("9")
+  }
+
+  "CsvRow" should "allow advanced operations for Nel-based Header types (CsvNelRow)" in {
+    val in = NonEmptyList.of("A" -> "1", "B" -> "3", "C" -> "5")
+    val testRow = CsvRow.fromNelHeaders(in)
+    testRow.size should be(3)
+    testRow("C") should contain ("5")
+    val modified = testRow.modify("C")(_ * 2)
+    modified("C") should contain ("55")
+    val updated = testRow.updated("A", "9")
+    updated(0) should contain("9")
+    testRow.toMap should contain(in.toList.toMap)
+  }
+
+}


### PR DESCRIPTION
Let ParseableHeader return errors if parsing fails so that more interesting header parsers can be written and parsing can fail early if headers are not as expected. Also make CsvRow a case class to allow for pattern matching.

Use case example: CSV with translations, first column being the key, the other columns being the languages identified by the headers. As it doesn't make sense to parse the file when the languages are invalid, it's nice to be able to fail on header parsing already instead of having to revalidate the headers on every row.