### PR TITLE
utf8 compatible CSV parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ val input = """i,s,j
               |,other,-3
               |""".stripMargin
 
-val stream = Stream.emits(input).through(rows[IO]())
+val stream = Stream.emits(input).through(utf8EncodeC).through(rows[IO]())
 println(stream.compile.toList.unsafeRunSync())
 ```
 

--- a/csv/src/fs2/data/csv/internals/ParseEnv.scala
+++ b/csv/src/fs2/data/csv/internals/ParseEnv.scala
@@ -17,5 +17,7 @@ package fs2
 package data
 package csv
 package internals
+import scala.collection.mutable
 
-private[internals] case class ParseEnv(currentField: StringBuilder, tail: List[String], state: State, idx: Int)
+
+private[internals] case class ParseEnv(currentField: mutable.ArrayBuilder[Byte], tail: List[String], state: State, idx: Int)

--- a/csv/src/fs2/data/csv/internals/RowParser.scala
+++ b/csv/src/fs2/data/csv/internals/RowParser.scala
@@ -152,6 +152,7 @@ private[csv] object RowParser {
       s.pull.uncons.flatMap {
         case Some((chunkOfChunks, rest)) =>
           val c = chunkOfChunks.flatMap(c => c)
+          env.currentField.sizeHint(c.size)
           row(c, env.currentField, env.tail, env.state, env.idx)
             .flatMap(go(rest, _))
         case None =>
@@ -172,10 +173,6 @@ private[csv] object RowParser {
       }
 
     s =>
-      go(s, ParseEnv({
-        val builder = Array.newBuilder[Byte]
-        builder.sizeHint(4096)
-        builder
-      }, Nil, State.BeginningOfField, 0)).stream
+      go(s, ParseEnv(Array.newBuilder[Byte], Nil, State.BeginningOfField, 0)).stream
   }
 }

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -27,11 +27,11 @@ package object csv {
 
   type DecoderResult[T] = Either[DecoderError, T]
 
-  /** Transforms a stream of characters into a stream of CSV rows.
+  /** Transforms a stream of bytes into a stream of CSV rows using a character set (encoding).
     */
-  def rows[F[_]](separator: Char = ',')(
-      implicit F: ApplicativeError[F, Throwable]): Pipe[F, Char, NonEmptyList[String]] =
-    RowParser.pipe[F](separator)
+  def rows[F[_]](separator: Char = ',', charSet: String = "UTF-8")(
+      implicit F: ApplicativeError[F, Throwable]): Pipe[F, Chunk[Byte], NonEmptyList[String]] =
+    RowParser.pipe[F](separator, charSet)
 
   /** Transforms a stream of raw CSV rows into parsed CSV rows with headers. */
   def headers[F[_], Header](implicit F: ApplicativeError[F, Throwable],

--- a/csv/test/src/fs2/data/csv/CsvParserTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvParserTest.scala
@@ -57,8 +57,7 @@ class CsvParserTest extends FlatSpec with Matchers with BeforeAndAfterAll {
       val actual =
         file
           .readAll[IO](path.path, blocker, 1024)
-          .through(fs2.text.utf8Decode)
-          .flatMap(Stream.emits(_))
+          .chunks
           .through(rows[IO]())
           .through(headers[IO, String])
           .compile


### PR DESCRIPTION
This changes the rows from Pipe[_, Char, _] to Pipe[_, Chunk[Byte], _] in order to support UTF-8 encoded CSV-files.
Goes without saying that this is not binary compatible with what was there before. However, Chunk[Byte] is arguably more natural to be the parse input type (at least in my book).

# Benchmarks
Benchmarks seems to be around the same, but the baseLine was much lower so uncertain what that means.

## csv-utf8-compatbile
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.openjdk.jmh.util.Utils (file:/home/freekh/.coursier/cache/v1/https/repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.23/jmh-core-1.23.jar) to field java.io.PrintStream.charOut
WARNING: Please consider reporting this to the maintainers of org.openjdk.jmh.util.Utils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
# JMH version: 1.23
# VM version: JDK 11.0.6, OpenJDK 64-Bit Server VM, 11.0.6+10
# VM invoker: /usr/lib/jvm/java-11-openjdk/bin/java
# VM options: <none>
# Warmup: 3 iterations, 2 s each
# Measurement: 5 iterations, 2 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: fs2.data.benchmarks.CsvParserBenchmarks.parseRows

# Run progress: 0.00% complete, ETA 00:00:32
# Fork: 1 of 1
# Warmup Iteration   1: 9382.941 us/op
# Warmup Iteration   2: 7442.770 us/op
# Warmup Iteration   3: 7449.140 us/op
Iteration   1: 7444.500 us/op
Iteration   2: 7381.815 us/op
Iteration   3: 7450.709 us/op
Iteration   4: 7549.906 us/op
Iteration   5: 7567.469 us/op


Result "fs2.data.benchmarks.CsvParserBenchmarks.parseRows":
  7478.880 ±(99.9%) 300.065 us/op [Average]
  (min, avg, max) = (7381.815, 7478.880, 7567.469), stdev = 77.926
  CI (99.9%): [7178.815, 7778.944] (assumes normal distribution)


# JMH version: 1.23
# VM version: JDK 11.0.6, OpenJDK 64-Bit Server VM, 11.0.6+10
# VM invoker: /usr/lib/jvm/java-11-openjdk/bin/java
# VM options: <none>
# Warmup: 3 iterations, 2 s each
# Measurement: 5 iterations, 2 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: fs2.data.benchmarks.CsvParserBenchmarks.parseRowsBaseline

# Run progress: 50.00% complete, ETA 00:00:16
# Fork: 1 of 1
# Warmup Iteration   1: 88.898 us/op
# Warmup Iteration   2: 62.168 us/op
# Warmup Iteration   3: 63.926 us/op
Iteration   1: 63.192 us/op
Iteration   2: 62.339 us/op
Iteration   3: 61.563 us/op
Iteration   4: 64.240 us/op
Iteration   5: 62.089 us/op


Result "fs2.data.benchmarks.CsvParserBenchmarks.parseRowsBaseline":
  62.685 ±(99.9%) 4.043 us/op [Average]
  (min, avg, max) = (61.563, 62.685, 64.240), stdev = 1.050
  CI (99.9%): [58.642, 66.728] (assumes normal distribution)


# Run complete. Total time: 00:00:32

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                              Mode  Cnt     Score     Error  Units
CsvParserBenchmarks.parseRows          avgt    5  7478.880 ± 300.065  us/op
CsvParserBenchmarks.parseRowsBaseline  avgt    5    62.685 ±   4.043  us/op
```
## master (dc5ea9849957ca30d132face2e730e6868539228)
```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.openjdk.jmh.util.Utils (file:/home/freekh/.coursier/cache/v1/https/repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.23/jmh-core-1.23.jar) to field java.io.PrintStream.charOut
WARNING: Please consider reporting this to the maintainers of org.openjdk.jmh.util.Utils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
# JMH version: 1.23
# VM version: JDK 11.0.6, OpenJDK 64-Bit Server VM, 11.0.6+10
# VM invoker: /usr/lib/jvm/java-11-openjdk/bin/java
# VM options: <none>
# Warmup: 3 iterations, 2 s each
# Measurement: 5 iterations, 2 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: fs2.data.benchmarks.CsvParserBenchmarks.parseRows

# Run progress: 0.00% complete, ETA 00:00:32
# Fork: 1 of 1
# Warmup Iteration   1: 10593.217 us/op
# Warmup Iteration   2: 8400.400 us/op
# Warmup Iteration   3: 8242.751 us/op
Iteration   1: 8327.449 us/op
Iteration   2: 8154.958 us/op
Iteration   3: 8233.273 us/op
Iteration   4: 8140.874 us/op
Iteration   5: 8153.118 us/op


Result "fs2.data.benchmarks.CsvParserBenchmarks.parseRows":
  8201.934 ±(99.9%) 304.750 us/op [Average]
  (min, avg, max) = (8140.874, 8201.934, 8327.449), stdev = 79.143
  CI (99.9%): [7897.184, 8506.685] (assumes normal distribution)


# JMH version: 1.23
# VM version: JDK 11.0.6, OpenJDK 64-Bit Server VM, 11.0.6+10
# VM invoker: /usr/lib/jvm/java-11-openjdk/bin/java
# VM options: <none>
# Warmup: 3 iterations, 2 s each
# Measurement: 5 iterations, 2 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: fs2.data.benchmarks.CsvParserBenchmarks.parseRowsBaseline

# Run progress: 50.00% complete, ETA 00:00:16
# Fork: 1 of 1
# Warmup Iteration   1: 4268.707 us/op
# Warmup Iteration   2: 3543.753 us/op
# Warmup Iteration   3: 3458.743 us/op
Iteration   1: 3462.324 us/op
Iteration   2: 3454.502 us/op
Iteration   3: 3476.015 us/op
Iteration   4: 3443.407 us/op
Iteration   5: 3461.670 us/op


Result "fs2.data.benchmarks.CsvParserBenchmarks.parseRowsBaseline":
  3459.584 ±(99.9%) 45.940 us/op [Average]
  (min, avg, max) = (3443.407, 3459.584, 3476.015), stdev = 11.931
  CI (99.9%): [3413.643, 3505.524] (assumes normal distribution)


# Run complete. Total time: 00:00:33

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                              Mode  Cnt     Score     Error  Units
CsvParserBenchmarks.parseRows          avgt    5  8201.934 ± 304.750  us/op
CsvParserBenchmarks.parseRowsBaseline  avgt    5  3459.584 ±  45.940  us/op
```