### PR TITLE
Fix CsvName on Option types

### DIFF
--- a/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowDecoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowDecoder.scala
@@ -54,7 +54,7 @@ object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
       def fromWithDefault(row: CsvRow[String],
                           default: Option[Option[Head]] :: DefaultTail,
                           anno: Anno :: AnnoTail): DecoderResult[FieldType[Key, Option[Head]] :: Tail] = {
-        val head = row(witness.value.name) match {
+        val head = row(anno.head.fold(witness.value.name)(_.name)) match {
           case Some(head) if head.nonEmpty => Head(head).map(Some(_))
           case _                           => Right(default.head.flatten)
         }

--- a/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
+++ b/csv/generic/test/src/fs2/data/csv/generic/CsvRowDecoderTest.scala
@@ -34,10 +34,12 @@ class CsvRowDecoderTest extends FlatSpec with Matchers {
   case class Test(i: Int = 0, s: String, j: Option[Int])
   case class TestOrder(s: String, j: Int, i: Int)
   case class TestRename(s: String, @CsvName("j") k: Int, i: Int)
+  case class TestOptionRename(s: String, @CsvName("j") k: Option[Int], i: Int)
 
   val testDecoder = deriveCsvRowDecoder[Test]
   val testOrderDecoder = deriveCsvRowDecoder[TestOrder]
   val testRenameDecoder = deriveCsvRowDecoder[TestRename]
+  val testOptionRenameDecoder = deriveCsvRowDecoder[TestOptionRename]
 
   "case classes" should "be decoded properly by header name and not position" in {
     testDecoder(csvRow) shouldBe Right(Test(1, "test", Some(42)))
@@ -63,6 +65,11 @@ class CsvRowDecoderTest extends FlatSpec with Matchers {
 
   it should "be decoded according to their field renames" in {
     testRenameDecoder(csvRow) shouldBe Right(TestRename("test", 42, 1))
+  }
+
+  it should "be decoded according to their field renames if value is optional" in {
+    testOptionRenameDecoder(csvRow) shouldBe Right(TestOptionRename("test", Some(42), 1))
+    testOptionRenameDecoder(csvRowNoJ) shouldBe Right(TestOptionRename("test", None, 1))
   }
 
 }


### PR DESCRIPTION
`Option` has a special handling in the implicit derivation and this part lacked the check for field renames via `@CsvName`. This PR adds a test case covering this issue and fixes it.