### PR TITLE
Add Json selector interpolator

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -136,6 +136,28 @@ class JsonModule(val crossScalaVersion: String) extends Fs2DataModule with Cross
     def ivyDeps = super.ivyDeps() ++ Seq(ivy"org.gnieh::diffson-circe:4.0.2")
   }
 
+  object interpolators extends Fs2DataModule with PublishModule {
+    def scalaVersion = outer.scalaVersion
+    def moduleDeps = Seq(outer)
+    def ivyDeps =
+      Agg(ivy"com.propensive::contextual:1.2.1", ivy"org.scala-lang:scala-reflect:${scalaVersion()}")
+
+    def publishVersion = fs2DataVersion
+
+    def artifactName = "fs2-data-json-interpolators"
+
+    def pomSettings =
+      PomSettings(
+        description = "Json interpolators support",
+        organization = "org.gnieh",
+        url = fs2DataUrl,
+        licenses = Seq(fs2DataLicense),
+        versionControl = VersionControl.github("satabin", "fs2-data"),
+        developers = Seq(fs2DataDeveloper)
+      )
+
+  }
+
   object circe extends Fs2DataModule with PublishModule {
     def scalaVersion = outer.scalaVersion
     def moduleDeps = Seq(outer)

--- a/json/interpolators/src/fs2/data/json/interpolators/SelectorInterpolator.scala
+++ b/json/interpolators/src/fs2/data/json/interpolators/SelectorInterpolator.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data
+package json
+package interpolators
+
+import cats.implicits._
+
+import contextual._
+
+object SelectorInterpolator extends Verifier[Selector] {
+
+  def check(string: String): Either[(Int, String), Selector] =
+    new SelectorParser[Either[Throwable, *]](string).parse().leftMap {
+      case JsonSelectorException(msg, idx) => (idx, msg)
+      case t                               => (0, t.getMessage)
+    }
+
+}

--- a/json/interpolators/src/fs2/data/json/interpolators/package.scala
+++ b/json/interpolators/src/fs2/data/json/interpolators/package.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data
+package json
+
+import contextual.Prefix
+
+package object interpolators {
+
+  implicit class SelectorStringContext(sc: StringContext) {
+    val selector = Prefix(SelectorInterpolator, sc)
+  }
+
+}


### PR DESCRIPTION
This is done in another module so that the core Json library only
depends on fs2, and doesn't bring extra dependencies to user who do not
want it.