### PR TITLE
Use VectorBuilder as chunk accumulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ jdk:
 branches:
   only:
   - master
+  - 1.x

--- a/json/src/fs2/data/json/internal/TokenParser.scala
+++ b/json/src/fs2/data/json/internal/TokenParser.scala
@@ -20,8 +20,7 @@ package internals
 
 import text._
 
-import cats.data.Chain
-
+import scala.collection.immutable.VectorBuilder
 import scala.annotation.switch
 
 private[json] object TokenParser {
@@ -33,11 +32,13 @@ private[json] object TokenParser {
                 state: Int,
                 unicode: Int,
                 acc: StringBuilder,
-                chunkAcc: Chain[Token]): Pull[F, Token, Option[(T.Context, Chain[Token])]] = {
+                chunkAcc: VectorBuilder[Token]): Pull[F, Token, Option[(T.Context, VectorBuilder[Token])]] = {
       if (T.needsPull(context)) {
-        Pull.output(Chunk.chain(chunkAcc)) >> T.pullNext(context).flatMap {
-          case Some(context) => string_(context, key, state, unicode, acc, Chain.empty)
-          case None          => Pull.raiseError[F](new JsonException("unexpected end of input"))
+        Pull.output(Chunk.vector(chunkAcc.result())) >> T.pullNext(context).flatMap {
+          case Some(context) =>
+            chunkAcc.clear()
+            string_(context, key, state, unicode, acc, chunkAcc)
+          case None => Pull.raiseError[F](new JsonException("unexpected end of input"))
         }
       } else {
         val c = T.current(context)
@@ -60,7 +61,7 @@ private[json] object TokenParser {
               Pull.pure(
                 Some(
                   (T.advance(context),
-                   chunkAcc.append(if (key) Token.Key(acc.result) else Token.StringValue(acc.result)))))
+                   chunkAcc += (if (key) Token.Key(acc.result) else Token.StringValue(acc.result)))))
             else if (c == '\\')
               string_(T.advance(context), key, StringState.SeenBackslash, 0, acc, chunkAcc)
             else if (c >= 0x20 && c <= 0x10ffff)
@@ -91,7 +92,7 @@ private[json] object TokenParser {
     def number_(context: T.Context,
                 state: Int,
                 acc: StringBuilder,
-                chunkAcc: Chain[Token]): Pull[F, Token, Option[(T.Context, Chain[Token])]] = {
+                chunkAcc: VectorBuilder[Token]): Pull[F, Token, Option[(T.Context, VectorBuilder[Token])]] = {
       def step(c: Char, state: Int): Int =
         (c: @switch) match {
           case '-' =>
@@ -152,8 +153,10 @@ private[json] object TokenParser {
         }
 
       if (T.needsPull(context)) {
-        Pull.output(Chunk.chain(chunkAcc)) >> T.pullNext(context).flatMap {
-          case Some(context) => number_(context, state, acc, Chain.empty)
+        Pull.output(Chunk.vector(chunkAcc.result())) >> T.pullNext(context).flatMap {
+          case Some(context) =>
+            chunkAcc.clear()
+            number_(context, state, acc, chunkAcc)
           case None =>
             if (NumberState.isFinal(state))
               Pull.output1(Token.NumberValue(acc.result)) >> Pull.pure(None)
@@ -165,7 +168,7 @@ private[json] object TokenParser {
         (step(c, state): @switch) match {
           case NumberState.Invalid =>
             if (NumberState.isFinal(state))
-              Pull.pure(Some((context, chunkAcc.append(Token.NumberValue(acc.result)))))
+              Pull.pure(Some((context, chunkAcc += Token.NumberValue(acc.result))))
             else
               Pull.raiseError[F](new JsonException(s"invalid number character '$c'"))
           case state =>
@@ -178,17 +181,19 @@ private[json] object TokenParser {
                  expected: String,
                  eidx: Int,
                  token: Token,
-                 chunkAcc: Chain[Token]): Pull[F, Token, Option[(T.Context, Chain[Token])]] = {
+                 chunkAcc: VectorBuilder[Token]): Pull[F, Token, Option[(T.Context, VectorBuilder[Token])]] = {
       if (T.needsPull(context)) {
-        Pull.output(Chunk.chain(chunkAcc)) >> T.pullNext(context).flatMap {
-          case Some(context) => keyword_(context, expected, eidx, token, Chain.empty)
-          case None          => Pull.raiseError[F](new JsonException("unexpected end of input"))
+        Pull.output(Chunk.vector(chunkAcc.result())) >> T.pullNext(context).flatMap {
+          case Some(context) =>
+            chunkAcc.clear()
+            keyword_(context, expected, eidx, token, chunkAcc)
+          case None => Pull.raiseError[F](new JsonException("unexpected end of input"))
         }
       } else {
         val c = T.current(context)
         if (c == expected.charAt(eidx)) {
           if (eidx == expected.length - 1)
-            Pull.pure(Some((T.advance(context), chunkAcc.append(token))))
+            Pull.pure(Some((T.advance(context), chunkAcc += token)))
           else
             keyword_(T.advance(context), expected, eidx + 1, token, chunkAcc)
         } else {
@@ -197,20 +202,22 @@ private[json] object TokenParser {
       }
     }
 
-    def value_(context: T.Context, state: Int, chunkAcc: Chain[Token])(
-        implicit F: RaiseThrowable[F]): Pull[F, Token, Option[(T.Context, Chain[Token])]] =
+    def value_(context: T.Context, state: Int, chunkAcc: VectorBuilder[Token])(
+        implicit F: RaiseThrowable[F]): Pull[F, Token, Option[(T.Context, VectorBuilder[Token])]] =
       if (T.needsPull(context)) {
-        Pull.output(Chunk.chain(chunkAcc)) >> T.pullNext(context).flatMap {
-          case Some(context) => value_(context, state, Chain.empty)
-          case None          => Pull.raiseError[F](new JsonException("unexpected end of input"))
+        Pull.output(Chunk.vector(chunkAcc.result())) >> T.pullNext(context).flatMap {
+          case Some(context) =>
+            chunkAcc.clear()
+            value_(context, state, chunkAcc)
+          case None => Pull.raiseError[F](new JsonException("unexpected end of input"))
         }
       } else {
         val c = T.current(context)
         (c: @switch) match {
           case '{' =>
-            Pull.suspend(go_(T.advance(context), State.BeforeObjectKey, chunkAcc.append(Token.StartObject)))
+            Pull.suspend(go_(T.advance(context), State.BeforeObjectKey, chunkAcc += Token.StartObject))
           case '[' =>
-            Pull.suspend(go_(T.advance(context), State.BeforeArrayValue, chunkAcc.append(Token.StartArray)))
+            Pull.suspend(go_(T.advance(context), State.BeforeArrayValue, chunkAcc += Token.StartArray))
           case 't' => keyword_(context, "true", 0, Token.TrueValue, chunkAcc)
           case 'f' => keyword_(context, "false", 0, Token.FalseValue, chunkAcc)
           case 'n' => keyword_(context, "null", 0, Token.NullValue, chunkAcc)
@@ -221,7 +228,7 @@ private[json] object TokenParser {
         }
       }
 
-    def continue(state: Int)(result: Option[(T.Context, Chain[Token])])(implicit F: RaiseThrowable[F]) =
+    def continue(state: Int)(result: Option[(T.Context, VectorBuilder[Token])])(implicit F: RaiseThrowable[F]) =
       result match {
         case Some((context, chunkAcc)) =>
           go_(context, state, chunkAcc)
@@ -231,10 +238,12 @@ private[json] object TokenParser {
 
     def go_(context: T.Context,
             state: Int,
-            chunkAcc: Chain[Token]): Pull[F, Token, Option[(T.Context, Chain[Token])]] = {
+            chunkAcc: VectorBuilder[Token]): Pull[F, Token, Option[(T.Context, VectorBuilder[Token])]] = {
       if (T.needsPull(context)) {
-        Pull.output(Chunk.chain(chunkAcc)) >> T.pullNext(context).flatMap {
-          case Some(context) => go_(context, state, Chain.empty)
+        Pull.output(Chunk.vector(chunkAcc.result())) >> T.pullNext(context).flatMap {
+          case Some(context) =>
+            chunkAcc.clear()
+            go_(context, state, chunkAcc)
           case None =>
             Pull.pure(None)
         }
@@ -252,7 +261,7 @@ private[json] object TokenParser {
                     string_(T.advance(context), true, StringState.Normal, 0, new StringBuilder, chunkAcc)
                       .flatMap(res => continue(State.AfterObjectKey)(res))
                   case '}' =>
-                    Pull.pure(Some((T.advance(context), chunkAcc.append(Token.EndObject))))
+                    Pull.pure(Some((T.advance(context), chunkAcc += Token.EndObject)))
                   case _ => Pull.raiseError[F](new JsonException(s"unexpected '$c' before object key"))
                 }
               case State.ExpectObjectKey =>
@@ -275,7 +284,7 @@ private[json] object TokenParser {
                   case ',' =>
                     go_(T.advance(context), State.ExpectObjectKey, chunkAcc)
                   case '}' =>
-                    Pull.pure(Some((T.advance(context), chunkAcc.append(Token.EndObject))))
+                    Pull.pure(Some((T.advance(context), chunkAcc += Token.EndObject)))
                   case c => Pull.raiseError[F](new JsonException(s"unexpected '$c' after object value"))
                 }
               case State.ExpectArrayValue =>
@@ -284,7 +293,7 @@ private[json] object TokenParser {
               case State.BeforeArrayValue =>
                 (c: @switch) match {
                   case ']' =>
-                    Pull.pure(Some((T.advance(context), chunkAcc.append(Token.EndArray))))
+                    Pull.pure(Some((T.advance(context), chunkAcc += Token.EndArray)))
                   case c =>
                     value_(context, State.AfterArrayValue, chunkAcc)
                       .flatMap(res => continue(State.AfterArrayValue)(res))
@@ -292,7 +301,7 @@ private[json] object TokenParser {
               case State.AfterArrayValue =>
                 (c: @switch) match {
                   case ']' =>
-                    Pull.pure(Some((T.advance(context), chunkAcc.append(Token.EndArray))))
+                    Pull.pure(Some((T.advance(context), chunkAcc += Token.EndArray)))
                   case ',' =>
                     go_(T.advance(context), State.ExpectArrayValue, chunkAcc)
                   case c => Pull.raiseError[F](new JsonException(s"unexpected '$c' after array value"))
@@ -302,6 +311,6 @@ private[json] object TokenParser {
       }
     }
 
-    Stream.suspend(Stream.emit(T.create(s))).flatMap(go_(_, State.BeforeValue, Chain.empty).void.stream)
+    Stream.suspend(Stream.emit(T.create(s))).flatMap(go_(_, State.BeforeValue, new VectorBuilder).void.stream)
   }
 }


### PR DESCRIPTION
Benchmarks show that a lot of time is spent creating and converting
`Chain`, which are use to accumulate the chunks. By using a
`VectorBuilder` we have a more appropriate structure for the
accumulator, which we can reuse for each chunk.