### PR TITLE
Add mandatory field selector

### DIFF
--- a/json/src/fs2/data/json/JsonException.scala
+++ b/json/src/fs2/data/json/JsonException.scala
@@ -16,3 +16,5 @@
 package fs2.data.json
 
 class JsonException(msg: String) extends Exception(msg)
+
+class JsonMissingFieldException(msg: String, val missing: Set[String]) extends Exception(msg)

--- a/json/src/fs2/data/json/internal/TokenSelector.scala
+++ b/json/src/fs2/data/json/internal/TokenSelector.scala
@@ -43,12 +43,13 @@ private[json] object TokenSelector {
       emitNonSelected: Boolean,
       wrap: Boolean,
       toSelect: String => Boolean,
+      mandatories: Set[String],
       onSelect: (Chunk[Token], Int, Stream[F, Token], List[Token]) => Pull[F, Token, Result[F, Token, List[Token]]],
       chunkAcc: List[Token])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
     if (idx >= chunk.size) {
       Pull.output(Chunk.seq(chunkAcc.reverse)) >>
         rest.pull.uncons.flatMap {
-          case Some((hd, tl)) => selectName(hd, 0, tl, emitNonSelected, wrap, toSelect, onSelect, Nil)
+          case Some((hd, tl)) => selectName(hd, 0, tl, emitNonSelected, wrap, toSelect, mandatories, onSelect, Nil)
           case None           => Pull.raiseError[F](new JsonException("unexpected end of input"))
         }
     } else
@@ -68,15 +69,20 @@ private[json] object TokenSelector {
             }
           action.flatMap {
             case Some((chunk, idx, rest, chunkAcc)) =>
-              selectName(chunk, idx, rest, emitNonSelected, wrap, toSelect, onSelect, chunkAcc)
+              selectName(chunk, idx, rest, emitNonSelected, wrap, toSelect, mandatories - name, onSelect, chunkAcc)
             case None =>
               Pull.raiseError[F](new JsonException("unexpected end of input"))
           }
 
         case Token.EndObject =>
           // object is done, go up
-          val chunkAcc1 = if (wrap) Token.EndObject :: chunkAcc else chunkAcc
-          Pull.pure(Some((chunk, idx + 1, rest, chunkAcc1)))
+          // but first check if all mandatory fields have been seen
+          if (mandatories.isEmpty) {
+            val chunkAcc1 = if (wrap) Token.EndObject :: chunkAcc else chunkAcc
+            Pull.pure(Some((chunk, idx + 1, rest, chunkAcc1)))
+          } else {
+            Pull.raiseError[F](new JsonMissingFieldException(s"missing mandatory fields: ${mandatories.mkString(", ")}", mandatories))
+          }
         case token =>
           Pull.raiseError[F](new JsonException("malformed json"))
       }
@@ -139,12 +145,12 @@ private[json] object TokenSelector {
       selector match {
         case Selector.ThisSelector =>
           onSelect(chunk, idx, rest, chunkAcc)
-        case Selector.NameSelector(pred, strict) =>
+        case Selector.NameSelector(pred, strict, mandatory) =>
           chunk(idx) match {
             case Token.StartObject =>
               // enter the object context and go down to the name
               val chunkAcc1 = if (wrap) Token.StartObject :: chunkAcc else chunkAcc
-              selectName(chunk, idx + 1, rest, emitNonSelected, wrap, pred, onSelect, chunkAcc1)
+              selectName(chunk, idx + 1, rest, emitNonSelected, wrap, pred, pred.values, onSelect, chunkAcc1)
             case token =>
               if (strict)
                 Pull.raiseError[F](new JsonException(s"cannot ${token.kind} number with string"))
@@ -178,7 +184,7 @@ private[json] object TokenSelector {
             case Token.StartObject =>
               // enter the object context and go down to the name
               val chunkAcc1 = if (wrap) Token.StartObject :: chunkAcc else chunkAcc
-              selectName(chunk, idx + 1, rest, emitNonSelected, wrap, NamePredicate.All, onSelect, chunkAcc1)
+              selectName(chunk, idx + 1, rest, emitNonSelected, wrap, NamePredicate.All, Set.empty, onSelect, chunkAcc1)
             case token =>
               if (strict)
                 Pull.raiseError[F](new JsonException(s"cannot iterate over ${token.kind}"))

--- a/json/test/src/fs2/data/json/JsonSelectorSpec.scala
+++ b/json/test/src/fs2/data/json/JsonSelectorSpec.scala
@@ -1,0 +1,84 @@
+package fs2
+package data
+package json
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.Inside
+
+class JsonSelectorSpec extends AnyFlatSpec with Matchers with Inside {
+
+  "mandatory fields" should "fail in the missing single case" in {
+    val selector = Selector.NameSelector("field", true, true)
+    val filtered = Stream(Token.StartObject, Token.Key("other-field"), Token.TrueValue, Token.EndObject)
+      .through(filter[Fallible](selector))
+      .compile
+      .drain
+
+    inside(filtered) {
+      case Left(e: JsonMissingFieldException) => e.missing shouldBe Set("field")
+    }
+  }
+
+  it should "fail in case at least one is missing" in {
+    val selector = Selector.NameSelector(Set("field1", "field2", "field3"), true, true)
+    val filtered = Stream(Token.StartObject, Token.Key("field2"), Token.TrueValue, Token.EndObject)
+      .through(filter[Fallible](selector))
+      .compile
+      .drain
+
+    inside(filtered) {
+      case Left(e: JsonMissingFieldException) => e.missing shouldBe Set("field1", "field3")
+    }
+  }
+
+  it should "fail in missing nested cases" in {
+    val selector = Selector.PipeSelector(Selector.IteratorSelector(true), Selector.NameSelector("field", true, true))
+    val filtered = Stream(Token.StartArray,
+                          Token.StartObject,
+                          Token.Key("other-field"),
+                          Token.TrueValue,
+                          Token.EndObject,
+                          Token.EndArray)
+      .through(filter[Fallible](selector))
+      .compile
+      .drain
+
+    inside(filtered) {
+      case Left(e: JsonMissingFieldException) => e.missing shouldBe Set("field")
+    }
+  }
+
+  it should "fail on outermost error in case of nested missing keys" in {
+    val selector =
+      Selector.PipeSelector(Selector.NameSelector("field1", true, true), Selector.NameSelector("field2", true, true))
+    val filtered =
+      Stream(Token.StartObject, Token.Key("other-field"), Token.StartObject, Token.EndObject, Token.EndObject)
+        .through(filter[Fallible](selector))
+        .compile
+        .drain
+
+    inside(filtered) {
+      case Left(e: JsonMissingFieldException) => e.missing shouldBe Set("field1")
+    }
+  }
+
+  it should "success if all mandatory fields are present" in {
+    val selector = Selector.NameSelector(Set("field1", "field2", "field3"), true, true)
+    val filtered = Stream(
+      Token.StartObject,
+      Token.Key("field2"),
+      Token.TrueValue,
+      Token.Key("field1"),
+      Token.StringValue("test"),
+      Token.Key("other-field"),
+      Token.NullValue,
+      Token.Key("field3"),
+      Token.NumberValue("1"),
+      Token.EndObject
+    ).through(filter[Fallible](selector)).compile.drain
+
+    filtered shouldBe Right(())
+  }
+
+}


### PR DESCRIPTION
This selector fails the stream if a selected field is not present in the
object the selector is applied to. It can be useful when you know your
data must contain the field and want to raise an error if not (e.g. to
detect typos).

fixes #30