### PR TITLE
Ensure all values are emitted before raising

### DIFF
--- a/documentation/docs/json/index.md
+++ b/documentation/docs/json/index.md
@@ -94,7 +94,7 @@ val mandatorySelector = ".field2!".parseSelector[ThrowableEither].toTry.get
 stream.through(filter(mandatorySelector)).compile.toList
 ```
 
-The `filter` preserves the chunk structure, so that the stream fails as soon as an error is encountered in the chunk, discarding potential previously selected values in the same chunk.
+The `filter` preserves the chunk structure, so that the stream fails as soon as an error is encountered in the chunk, but first emitting previously selected values in the same chunk.
 
 ### AST builder and tokenizer
 

--- a/json/src/fs2/data/json/internal/package.scala
+++ b/json/src/fs2/data/json/internal/package.scala
@@ -23,6 +23,9 @@ package object internals {
 
   private[json] type Result[F[_], In, Out] = Option[(Chunk[In], Int, Stream[F, In], Out)]
 
+  private[json] def emitChunk[T](chunkAcc: List[T]) =
+    Pull.output(Chunk.seq(chunkAcc.reverse))
+
   private[json] def skipValue[F[_]](
       chunk: Chunk[Token],
       idx: Int,

--- a/json/test/src/fs2/data/json/JsonExceptionSpec.scala
+++ b/json/test/src/fs2/data/json/JsonExceptionSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2.data.json
+
+import fs2._
+
+import circe._
+
+import cats.implicits._
+
+import _root_.io.circe.Json
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JsonExceptionSpec extends AnyFlatSpec with Matchers {
+
+  "previous valid tokens" should "be emitted before Exception" in {
+
+    val input = """{"key": }"""
+
+    val stream = Stream.emits(input).through(tokens[Fallible]).attempt
+
+    stream.compile.toList should matchPattern {
+      case Right(List(Right(Token.StartObject), Right(Token.Key("key")), Left(_: JsonException))) =>
+    }
+
+  }
+
+  "previous selected tokens" should "be emitted before Exception" in {
+
+    val input = """{"key1": 1}[]"""
+
+    val selector = ".key1".parseSelector[Either[Throwable, *]].fold(throw _, identity)
+    val stream = Stream.emits(input).through(tokens[Fallible]).through(filter(selector)).attempt
+
+    stream.compile.toList should matchPattern {
+      case Right(List(Right(Token.NumberValue("1")), Left(_: JsonException))) =>
+    }
+
+  }
+
+  "previous valid values" should "be emitted before Exception" in {
+
+    val input = """{"key": "value"}[1,"""
+
+    val stream = Stream.emits(input).through(tokens[Fallible]).through(values).attempt
+
+    stream.compile.toList should matchPattern {
+      case Right(List(Right(o), Left(_: JsonException))) if o == Json.obj("key" -> Json.fromString("value")) =>
+    }
+
+  }
+
+}

--- a/xml/src/fs2/data/xml/internals/package.scala
+++ b/xml/src/fs2/data/xml/internals/package.scala
@@ -21,4 +21,7 @@ package object internals {
 
   private[internals] type Result[F[_], O] = (Context[F], O)
 
+  private[internals] def emitChunk[T](chunkAcc: List[T]) =
+    Pull.output(Chunk.seq(chunkAcc.reverse))
+
 }

--- a/xml/test/src/fs2/data/xml/XmlExceptionSpec.scala
+++ b/xml/test/src/fs2/data/xml/XmlExceptionSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2.data.xml
+
+import fs2._
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class XmlExceptionSpec extends AnyFlatSpec with Matchers {
+
+  "previous valid events" should "be emitted before Exception" in {
+
+    val input = """<a><b>c</a>"""
+
+    val stream = Stream.emits(input).through(events[Fallible]).attempt
+
+    stream.compile.toList should matchPattern {
+      case Right(
+          List(Right(XmlEvent.StartTag(QName(None, "a"), Nil, false)),
+               Right(XmlEvent.StartTag(QName(None, "b"), Nil, false)),
+               Right(XmlEvent.XmlString("c", false)),
+               Left(_: XmlException))) =>
+    }
+
+  }
+
+}


### PR DESCRIPTION
The idea is to have a stream that emits all valid values up to the first
exception. Discarding the currently accumulating chunk can result in
some data being sometimes emitted or not, depending on the chunk size.
Observable behavior of the stream should not depend on how data is
chunked, so all valid data _so far_ must always be emitted.