### PR TITLE
Customize csv quote handling

### DIFF
--- a/csv/src/fs2/data/csv/internals/RowParser.scala
+++ b/csv/src/fs2/data/csv/internals/RowParser.scala
@@ -18,6 +18,8 @@ package data
 package csv
 package internals
 
+import cats.data.{State => _, _}
+
 private[csv] object RowParser {
 
   def pipe[F[_]](separator: Char,
@@ -77,7 +79,7 @@ private[csv] object RowParser {
               Pull.raiseError[F](new CsvException(s"unexpected character '$c'"))
             }
           case State.BeginningOfField =>
-            if (c == '"' && quoteHandling == QuoteHandling.Adaptive) {
+            if (c == '"' && quoteHandling == QuoteHandling.RFCCompliant) {
               // start a quoted field
               row(chunk, currentField, tail, State.InQuoted, idx + 1)
             } else if (c == separator) {

--- a/csv/src/fs2/data/csv/internals/RowParser.scala
+++ b/csv/src/fs2/data/csv/internals/RowParser.scala
@@ -22,8 +22,7 @@ import cats.data.{State => _, _}
 
 private[csv] object RowParser {
 
-  def pipe[F[_]](separator: Char,
-                 quoteHandling: QuoteHandling = QuoteHandling.Adaptive)(
+  def pipe[F[_]](separator: Char, quoteHandling: QuoteHandling)(
       implicit F: RaiseThrowable[F]): Pipe[F, Char, NonEmptyList[String]] = {
 
     def row(chunk: Chunk[Char],

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -48,6 +48,13 @@ package object csv {
   }
 
   /** Transforms a stream of characters into a stream of CSV rows.
+    *
+    * @param separator character to use to separate fields in the CSV
+    * @param quoteHandling use [[QuoteHandling.RFCCompliant]] for RFC-4180
+    *                      handling of quotation marks (optionally quoted
+    *                      if the value begins with a quotation mark; the
+    *                      default) or [[QuoteHandling.Literal]] if quotation
+    *                      marks should be treated literally
     */
   def rows[F[_]](separator: Char = ',', quoteHandling: QuoteHandling = QuoteHandling.RFCCompliant)(
       implicit F: RaiseThrowable[F]): Pipe[F, Char, NonEmptyList[String]] =

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -36,7 +36,7 @@ package object csv {
       *
       * For example, "hello, world" would be parsed as unquoted `hello, world`
       */
-    case object Adaptive extends QuoteHandling
+    case object RFCCompliant extends QuoteHandling
 
     /** Treats values as raw strings and does not treat quotation marks with
       * any particular meaning
@@ -44,12 +44,12 @@ package object csv {
       * For example, "hello, world" would be parsed as the still-quoted
       * `"hello, world"`
       */
-    case object Disabled extends QuoteHandling
+    case object Literal extends QuoteHandling
   }
 
   /** Transforms a stream of characters into a stream of CSV rows.
     */
-  def rows[F[_]](separator: Char = ',', quoteHandling: QuoteHandling = QuoteHandling.Adaptive)(
+  def rows[F[_]](separator: Char = ',', quoteHandling: QuoteHandling = QuoteHandling.RFCCompliant)(
       implicit F: RaiseThrowable[F]): Pipe[F, Char, NonEmptyList[String]] =
     RowParser.pipe[F](separator, quoteHandling)
 

--- a/documentation/docs/csv/index.md
+++ b/documentation/docs/csv/index.md
@@ -42,6 +42,21 @@ val stream2 = Stream.emits(input2).through(rows[IO](';'))
 stream2.compile.toList.unsafeRunSync()
 ```
 
+Often, CSVs don't conform to RFC4180 and quotation marks should be treated as literal quotation marks rather than denoting a quoted value. You are able to specify quote-handling behavior to the `rows` pipe as well. For instance:
+
+```scala mdoc
+val input3 =
+  """name,age,description
+    |John Doe,47,no quotes
+    |Jane Doe,50,"entirely quoted"
+    |Bob Smith,80,"starts with" a quote
+    |Alice Grey,78,contains "a quote""".stripMargin
+
+// default quote-handling is QuoteHandling.RFCCompliant
+val stream3 = Stream.emits(input3).through(rows[IO](',', QuoteHandling.Literal))
+stream3.compile.toList.unsafeRunSync()
+```
+
 ### CSV rows with or without headers
 
 Rows can be converted to a `Row` or `CsvRow[Header]` for some `Header` type. These classes provides higher-level utilities to manipulate rows.


### PR DESCRIPTION
We had a use case recently where we have an unquoted CSV to parse that contains values with quotation marks. An example might be:

```
name,age,description
John Doe,75,"Starts with Quotes" but ends without
```

The current parser assumes a field beginning with a quote is a quoted field, per RFC, but the data here doesn't reflect that and we need all quotes to be treated literally.

This PR allows for a parsing flag to treat quotes either RFC-compliant or literal.

Note: it probably could use a dedicated test. I wanted to put this up first to get some eyes on it, however.