### PR TITLE
Check consistency between row and header length

### DIFF
--- a/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowEncoder.scala
+++ b/csv/generic/src/fs2/data/csv/generic/MapShapedCsvRowEncoder.scala
@@ -29,7 +29,7 @@ object MapShapedCsvRowEncoder extends LowPrioMapShapedCsvRowEncoderImplicits {
       ev: <:<[Anno, Option[CsvName]],
       witness: Witness.Aux[Key]): WithAnnotations[Wrapped, FieldType[Key, Repr] :: HNil, Anno :: HNil] =
     (row: Repr :: HNil, annotation: Anno :: HNil) =>
-      CsvRow(NonEmptyList.one(Last(row.head)), NonEmptyList.one(annotation.head.fold(witness.value.name)(_.name)))
+      new CsvRow(NonEmptyList.one(Last(row.head)), NonEmptyList.one(annotation.head.fold(witness.value.name)(_.name)))
 
 }
 
@@ -51,7 +51,7 @@ trait LowPrioMapShapedCsvRowEncoderImplicits {
       : WithAnnotations[Wrapped, FieldType[Key, Head] :: Tail, Anno :: AnnoTail] =
     (row: FieldType[Key, Head] :: Tail, annotation: Anno :: AnnoTail) => {
       val tailRow = Tail.value.fromWithAnnotation(row.tail, annotation.tail)
-      CsvRow(NonEmptyList(Head(row.head), tailRow.values.toList),
-             NonEmptyList(annotation.head.fold(witness.value.name)(_.name), tailRow.headers.toList))
+      new CsvRow(NonEmptyList(Head(row.head), tailRow.values.toList),
+                 NonEmptyList(annotation.head.fold(witness.value.name)(_.name), tailRow.headers.toList))
     }
 }

--- a/csv/src/fs2/data/csv/CsvRow.scala
+++ b/csv/src/fs2/data/csv/CsvRow.scala
@@ -74,7 +74,11 @@ object Row {
   def apply(values: NonEmptyList[String]): Row = new Row(values)
 }
 
-case class CsvRow[Header](override val values: NonEmptyList[String], headers: NonEmptyList[Header])
+/** A CSV row with headers, that can be used to access the cell values.
+  *
+  * '''Note:''' the following invariant holds when using this class: `values` and `headers` have the same size.
+  */
+case class CsvRow[Header] private[csv] (override val values: NonEmptyList[String], headers: NonEmptyList[Header])
     extends Row(values) {
 
   private lazy val byHeader: Map[Header, String] =
@@ -83,7 +87,7 @@ case class CsvRow[Header](override val values: NonEmptyList[String], headers: No
   /** Modifies the cell content at the given `idx` using the function `f`.
     */
   override def modify(idx: Int)(f: String => String): CsvRow[Header] =
-    copy(values = super.modify(idx)(f).values)
+    new CsvRow(super.modify(idx)(f).values, headers)
 
   /** Modifies the cell content at the given `header` using the function `f`.
     *
@@ -155,6 +159,15 @@ case class CsvRow[Header](override val values: NonEmptyList[String], headers: No
 }
 
 object CsvRow {
+
+  /** Constructs a [[CsvRow]] and checks that the size of values and headers match. */
+  def apply[Header](values: NonEmptyList[String], headers: NonEmptyList[Header]): Either[CsvException, CsvRow[Header]] =
+    if (values.length =!= headers.length)
+      Left(
+        new CsvException(
+          s"Headers have size ${headers.length} but row has size ${values.length}. Both numbers must match!"))
+    else
+      Right(new CsvRow(values, headers))
 
   def fromListHeaders[Header](l: List[(Header, String)]): Option[CsvRow[Header]] = {
     val (hs, vs) = l.unzip

--- a/csv/src/fs2/data/csv/internals/CsvRowParser.scala
+++ b/csv/src/fs2/data/csv/internals/CsvRowParser.scala
@@ -33,7 +33,12 @@ private[csv] object CsvRowParser {
             val error = new HeaderError(
               s"Got ${headers.length} headers, but ${firstRow.length} columns. Both numbers must match!")
             Pull.raiseError[F](error)
-          case Right(headers) => tail.map(CsvRow[Header](_, headers)).pull.echo
+          case Right(headers) =>
+            tail
+              .map(CsvRow(_, headers))
+              .rethrow
+              .pull
+              .echo
         }
       case None => Pull.done
     }.stream

--- a/csv/src/fs2/data/csv/package.scala
+++ b/csv/src/fs2/data/csv/package.scala
@@ -66,8 +66,9 @@ package object csv {
     CsvRowParser.pipe[F, Header]
 
   /** Transforms a stream of raw CSV rows into parsed CSV rows with given headers. */
-  def withHeaders[F[_], Header](headers: NonEmptyList[Header]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
-    _.map(CsvRow(_, headers))
+  def withHeaders[F[_], Header](headers: NonEmptyList[Header])(
+      implicit F: RaiseThrowable[F]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
+    _.map(CsvRow(_, headers)).rethrow
 
   /** Transforms a stream of raw CSV rows into rows. */
   def noHeaders[F[_]]: Pipe[F, NonEmptyList[String], Row] =

--- a/csv/test/src/fs2/data/csv/CsvParserTest.scala
+++ b/csv/test/src/fs2/data/csv/CsvParserTest.scala
@@ -27,6 +27,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.concurrent._
 import better.files.{Resource => _, _}
 import java.util.concurrent._
+import cats.data.NonEmptyList
 
 class CsvParserTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
@@ -83,6 +84,32 @@ class CsvParserTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
           .map(_.toMap)
 
       reencoded should be(expected)
+    }
+  }
+
+  "Row parser" should "check row length against header length" in {
+    val rows = Stream.emits(
+      List(NonEmptyList.of("header1", "header2"),
+           NonEmptyList.of("c11", "c12"),
+           NonEmptyList.of("c21", "c22", "c23"),
+           NonEmptyList.of("c31", "c32")))
+
+    val compiled = rows.through(headers[Fallible, String]).compile.drain
+
+    compiled should matchPattern {
+      case Left(_: CsvException) =>
+    }
+  }
+
+  it should "fail decoding if row length doesn't match header length" in {
+    val headers = NonEmptyList.of("header1", "header2")
+    val rows = Stream.emits(
+      List(NonEmptyList.of("c11", "c12"), NonEmptyList.of("c21"), NonEmptyList.of("c31", "c32")))
+
+    val compiled = rows.through(withHeaders[Fallible, String](headers)).compile.drain
+
+    compiled should matchPattern {
+      case Left(_: CsvException) =>
     }
   }
 


### PR DESCRIPTION
When a header row is required by the user, then it is better to check
consistency of following rows, so that we do not emit bogus rows where
length of headers and values do not match. This can lead to hard to spot
and debug problems.

Fixes #51