### PR TITLE
Add HeaderSizeError for downstream consumers to match on

### DIFF
--- a/csv/src/fs2/data/csv/exceptions.scala
+++ b/csv/src/fs2/data/csv/exceptions.scala
@@ -20,3 +20,7 @@ class CsvException(msg: String, inner: Throwable = null) extends Exception(msg, 
 class DecoderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)
 
 class HeaderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)
+
+/** Raised when processing a Csv row whose width doesn't match the width of the Csv header row */
+class HeaderSizeError(msg: String, val expectedColumns: Int, val actualColumns: Int, inner: Throwable = null)
+    extends HeaderError(msg, inner)

--- a/csv/src/fs2/data/csv/internals/CsvRowParser.scala
+++ b/csv/src/fs2/data/csv/internals/CsvRowParser.scala
@@ -26,12 +26,14 @@ private[csv] object CsvRowParser {
   def pipe[F[_], Header](implicit F: RaiseThrowable[F],
                          Header: ParseableHeader[Header]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
     _.pull.uncons1.flatMap {
-      case Some((firstRow, tail)) =>
-        Header(firstRow) match {
+      case Some((currentRow, tail)) =>
+        Header(currentRow) match {
           case Left(error) => Pull.raiseError[F](error)
-          case Right(headers) if headers.length =!= firstRow.length =>
-            val error = new HeaderError(
-              s"Got ${headers.length} headers, but ${firstRow.length} columns. Both numbers must match!")
+          case Right(headers) if headers.length =!= currentRow.length =>
+            val error = new HeaderSizeError(
+              s"Got ${headers.length} headers, but ${currentRow.length} columns. Both numbers must match!",
+              expectedColumns = headers.length,
+              actualColumns = currentRow.length)
             Pull.raiseError[F](error)
           case Right(headers) =>
             tail


### PR DESCRIPTION
When raising header size mismatches, use this specific error.

It will cause, for example, exception reporting software like Sentry to
correlate these exceptions separately from logical errors like a bad Decoder

This should be backwards compatible since it's a subclass