### PR TITLE
Add JSON context in when using selectors

### DIFF
--- a/json/shared/src/main/scala/fs2/data/json/JsonContext.scala
+++ b/json/shared/src/main/scala/fs2/data/json/JsonContext.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data
+package json
+
+import cats.Show
+import cats.implicits._
+
+/** A JSON trace context, positioning the current location in the JSON value
+  * starting from the root.
+  */
+sealed trait JsonContext
+
+object JsonContext {
+  case object Root extends JsonContext
+  case class Key(name: String, parent: JsonContext) extends JsonContext
+  case class Index(idx: Long, parent: JsonContext) extends JsonContext
+
+  implicit object JsonContextShow extends Show[JsonContext] {
+    def show(t: JsonContext): String = t match {
+      case Root => "/"
+      case Key(name, Root) => show"/$name"
+      case Key(name, parent) => show"$parent/$name"
+      case Index(idx, Root) => show"/$idx"
+      case Index(idx, parent) => show"$parent/$idx"
+    }
+  }
+}

--- a/json/shared/src/main/scala/fs2/data/json/JsonException.scala
+++ b/json/shared/src/main/scala/fs2/data/json/JsonException.scala
@@ -15,6 +15,7 @@
  */
 package fs2.data.json
 
-class JsonException(msg: String) extends Exception(msg)
+class JsonException(msg: String, val context: Option[JsonContext] = None, val inner: Throwable = null)
+    extends Exception(msg, inner)
 
 class JsonMissingFieldException(msg: String, val missing: Set[String]) extends Exception(msg)

--- a/json/shared/src/main/scala/fs2/data/json/internal/TokenSelector.scala
+++ b/json/shared/src/main/scala/fs2/data/json/internal/TokenSelector.scala
@@ -26,9 +26,10 @@ private[json] object TokenSelector {
                                          idx: Int,
                                          rest: Stream[F, Token],
                                          f: Json => Option[Json],
+                                         context: JsonContext,
                                          chunkAcc: List[Token],
-                                         key: Option[String])(
-      implicit F: RaiseThrowable[F],
+                                         key: Option[String])(implicit
+      F: RaiseThrowable[F],
       builder: Builder[Json],
       tokenizer: Tokenizer[Json]): Pull[F, Token, Result[F, Token, List[Token]]] =
     ValueParser.pullValue(chunk, idx, rest).flatMap {
@@ -45,40 +46,45 @@ private[json] object TokenSelector {
                                           idx: Int,
                                           rest: Stream[F, Token],
                                           f: Json => F[Json],
+                                          context: JsonContext,
                                           chunkAcc: List[Token],
-                                          key: Option[String])(
-      implicit F: RaiseThrowable[F],
+                                          key: Option[String])(implicit
+      F: RaiseThrowable[F],
       builder: Builder[Json],
       tokenizer: Tokenizer[Json]): Pull[F, Token, Result[F, Token, List[Token]]] =
     ValueParser.pullValue(chunk, idx, rest).flatMap {
       case Some((chunk, idx, rest, json)) =>
         Pull
           .eval(f(json))
-          .handleErrorWith(t => emitChunk(chunkAcc) >> Pull.raiseError(t))
+          .handleErrorWith(t =>
+            emitChunk(chunkAcc) >> Pull.raiseError(
+              new JsonException("An error occurred while transforming Json data", Some(context), t)))
           .map(transformed => Some((chunk, idx, rest, tokenizer.tokenize(transformed).toList reverse_::: chunkAcc)))
       case None => Pull.pure(None)
     }
 
-  private def selectName[F[_]](
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      emitNonSelected: Boolean,
-      wrap: Boolean,
-      emitEarly: Boolean,
-      toSelect: String => Boolean,
-      mandatories: Set[String],
-      onSelect: (Chunk[Token],
-                 Int,
-                 Stream[F, Token],
-                 List[Token],
-                 Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
-      chunkAcc: List[Token])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+  private def selectName[F[_]](chunk: Chunk[Token],
+                               idx: Int,
+                               rest: Stream[F, Token],
+                               emitNonSelected: Boolean,
+                               wrap: Boolean,
+                               emitEarly: Boolean,
+                               toSelect: String => Boolean,
+                               mandatories: Set[String],
+                               context: JsonContext,
+                               onSelect: (Chunk[Token],
+                                          Int,
+                                          Stream[F, Token],
+                                          JsonContext,
+                                          List[Token],
+                                          Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
+                               chunkAcc: List[Token])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
     if (idx >= chunk.size) {
       emitChunk(chunkAcc) >> rest.pull.uncons.flatMap {
         case Some((hd, tl)) =>
-          selectName(hd, 0, tl, emitNonSelected, wrap, emitEarly, toSelect, mandatories, onSelect, Nil)
-        case None => Pull.raiseError[F](new JsonException("unexpected end of input"))
+          selectName(hd, 0, tl, emitNonSelected, wrap, emitEarly, toSelect, mandatories, context, onSelect, Nil)
+        case None => Pull.raiseError[F](new JsonException("unexpected end of input", Some(context)))
       }
     } else
       chunk(idx) match {
@@ -87,7 +93,7 @@ private[json] object TokenSelector {
             if (toSelect(name)) {
               // name is to be selected, then continue
               val chunkAcc1 = if (wrap && emitEarly) key :: chunkAcc else chunkAcc
-              onSelect(chunk, idx + 1, rest, chunkAcc1, Some(name))
+              onSelect(chunk, idx + 1, rest, JsonContext.Key(name, context), chunkAcc1, Some(name))
             } else if (emitNonSelected) {
               val chunkAcc1 = if (wrap) key :: chunkAcc else chunkAcc
               emitValue(chunk, idx + 1, rest, 0, chunkAcc1)
@@ -105,10 +111,11 @@ private[json] object TokenSelector {
                          emitEarly,
                          toSelect,
                          mandatories - name,
+                         JsonContext.Key(name, context),
                          onSelect,
                          chunkAcc)
             case None =>
-              Pull.raiseError[F](new JsonException("unexpected end of input"))
+              Pull.raiseError[F](new JsonException("unexpected end of input", Some(context)))
           }
 
         case Token.EndObject =>
@@ -122,27 +129,29 @@ private[json] object TokenSelector {
               new JsonMissingFieldException(s"missing mandatory fields: ${mandatories.mkString(", ")}", mandatories))
           }
         case token =>
-          emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException("malformed json"))
+          emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException("malformed json", Some(context)))
       }
 
-  private def selectIndex[F[_]](
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      emitNonSelected: Boolean,
-      wrap: Boolean,
-      arrIdx: Int,
-      toSelect: Int => Boolean,
-      onSelect: (Chunk[Token],
-                 Int,
-                 Stream[F, Token],
-                 List[Token],
-                 Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
-      chunkAcc: List[Token])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+  private def selectIndex[F[_]](chunk: Chunk[Token],
+                                idx: Int,
+                                rest: Stream[F, Token],
+                                emitNonSelected: Boolean,
+                                wrap: Boolean,
+                                arrIdx: Int,
+                                toSelect: Int => Boolean,
+                                context: JsonContext,
+                                onSelect: (Chunk[Token],
+                                           Int,
+                                           Stream[F, Token],
+                                           JsonContext,
+                                           List[Token],
+                                           Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
+                                chunkAcc: List[Token])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
     if (idx >= chunk.size) {
       emitChunk(chunkAcc) >> rest.pull.uncons.flatMap {
-        case Some((hd, tl)) => selectIndex(hd, 0, tl, emitNonSelected, wrap, arrIdx, toSelect, onSelect, Nil)
-        case None           => Pull.raiseError[F](new JsonException("unexpected end of input"))
+        case Some((hd, tl)) => selectIndex(hd, 0, tl, emitNonSelected, wrap, arrIdx, toSelect, context, onSelect, Nil)
+        case None           => Pull.raiseError[F](new JsonException("unexpected end of input", Some(context)))
       }
     } else
       chunk(idx) match {
@@ -154,7 +163,7 @@ private[json] object TokenSelector {
           val action =
             if (toSelect(arrIdx))
               // index is to be selected, then continue
-              onSelect(chunk, idx, rest, chunkAcc, None)
+              onSelect(chunk, idx, rest, JsonContext.Index(arrIdx, context), chunkAcc, None)
             else if (emitNonSelected)
               emitValue(chunk, idx, rest, 0, chunkAcc)
             else
@@ -162,35 +171,39 @@ private[json] object TokenSelector {
               skipValue(chunk, idx, rest, 0, chunkAcc)
           action.flatMap {
             case Some((chunk, idx, rest, chunkAcc)) =>
-              selectIndex(chunk, idx, rest, emitNonSelected, wrap, arrIdx + 1, toSelect, onSelect, chunkAcc)
-            case None => Pull.raiseError[F](new JsonException("unexpected end of input"))
+              selectIndex(chunk, idx, rest, emitNonSelected, wrap, arrIdx + 1, toSelect, context, onSelect, chunkAcc)
+            case None =>
+              Pull.raiseError[F](new JsonException("unexpected end of input", Some(context)))
           }
       }
 
-  private def filterChunk[F[_]](
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      selector: Selector,
-      emitNonSelected: Boolean,
-      wrap: Boolean,
-      emitEarly: Boolean,
-      onSelect: (Chunk[Token],
-                 Int,
-                 Stream[F, Token],
-                 List[Token],
-                 Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
-      chunkAcc: List[Token],
-      key: Option[String])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+  private def filterChunk[F[_]](chunk: Chunk[Token],
+                                idx: Int,
+                                rest: Stream[F, Token],
+                                selector: Selector,
+                                emitNonSelected: Boolean,
+                                wrap: Boolean,
+                                emitEarly: Boolean,
+                                context: JsonContext,
+                                onSelect: (Chunk[Token],
+                                           Int,
+                                           Stream[F, Token],
+                                           JsonContext,
+                                           List[Token],
+                                           Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
+                                chunkAcc: List[Token],
+                                key: Option[String])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
     if (idx >= chunk.size) {
       emitChunk(chunkAcc) >> rest.pull.uncons.flatMap {
-        case Some((hd, tl)) => filterChunk(hd, 0, tl, selector, emitNonSelected, wrap, emitEarly, onSelect, Nil, key)
-        case None           => Pull.pure(None)
+        case Some((hd, tl)) =>
+          filterChunk(hd, 0, tl, selector, emitNonSelected, wrap, emitEarly, context, onSelect, Nil, key)
+        case None => Pull.pure(None)
       }
     } else
       selector match {
         case Selector.ThisSelector =>
-          onSelect(chunk, idx, rest, chunkAcc, key)
+          onSelect(chunk, idx, rest, context, chunkAcc, key)
         case Selector.NameSelector(pred, strict, mandatory) =>
           chunk(idx) match {
             case Token.StartObject =>
@@ -204,11 +217,12 @@ private[json] object TokenSelector {
                          emitEarly,
                          pred,
                          if (mandatory) pred.values else Set.empty,
+                         context,
                          onSelect,
                          chunkAcc1)
             case token =>
               if (strict)
-                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot ${token.kind} number with string"))
+                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot index ${token.kind} with string", Some(context)))
               else if (emitNonSelected)
                 emitValue(chunk, idx, rest, 0, chunkAcc)
               else
@@ -220,10 +234,10 @@ private[json] object TokenSelector {
             case Token.StartArray =>
               // enter the array context and go down to the indices
               val chunkAcc1 = if (wrap) Token.StartArray :: chunkAcc else chunkAcc
-              selectIndex(chunk, idx + 1, rest, emitNonSelected, wrap, 0, pred, onSelect, chunkAcc1)
+              selectIndex(chunk, idx + 1, rest, emitNonSelected, wrap, 0, pred, context, onSelect, chunkAcc1)
             case token =>
               if (strict)
-                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot index ${token.kind} with number"))
+                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot index ${token.kind} with number", Some(context)))
               else if (emitNonSelected)
                 emitValue(chunk, idx, rest, 0, chunkAcc)
               else
@@ -235,7 +249,16 @@ private[json] object TokenSelector {
             case Token.StartArray =>
               // enter the array context and go down to the indices
               val chunkAcc1 = if (wrap) Token.StartArray :: chunkAcc else chunkAcc
-              selectIndex(chunk, idx + 1, rest, emitNonSelected, wrap, 0, IndexPredicate.All, onSelect, chunkAcc1)
+              selectIndex(chunk,
+                          idx + 1,
+                          rest,
+                          emitNonSelected,
+                          wrap,
+                          0,
+                          IndexPredicate.All,
+                          context,
+                          onSelect,
+                          chunkAcc1)
             case Token.StartObject =>
               // enter the object context and go down to the name
               val chunkAcc1 = if (wrap) Token.StartObject :: chunkAcc else chunkAcc
@@ -247,11 +270,12 @@ private[json] object TokenSelector {
                          emitEarly,
                          NamePredicate.All,
                          Set.empty,
+                         context,
                          onSelect,
                          chunkAcc1)
             case token =>
               if (strict)
-                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot iterate over ${token.kind}"))
+                emitChunk(chunkAcc) >> Pull.raiseError[F](new JsonException(s"cannot iterate over ${token.kind}", Some(context)))
               else if (emitNonSelected)
                 emitValue(chunk, idx, rest, 0, chunkAcc)
               else
@@ -267,7 +291,8 @@ private[json] object TokenSelector {
             emitNonSelected,
             wrap,
             true,
-            filterChunk(_, _, _, right, emitNonSelected, wrap, emitEarly, onSelect, _, _),
+            context,
+            filterChunk(_, _, _, right, emitNonSelected, wrap, emitEarly, _, onSelect, _, _),
             chunkAcc,
             key
           )
@@ -280,52 +305,59 @@ private[json] object TokenSelector {
                        emitNonSelected: Boolean,
                        wrap: Boolean,
                        emitEarly: Boolean,
+                       context: JsonContext,
                        onSelect: (Chunk[Token],
                                   Int,
                                   Stream[F, Token],
+                                  JsonContext,
                                   List[Token],
                                   Option[String]) => Pull[F, Token, Result[F, Token, List[Token]]],
                        chunkAcc: List[Token])(implicit F: RaiseThrowable[F]): Pull[F, Token, Unit] =
-    filterChunk(chunk, idx, rest, selector, emitNonSelected, wrap, emitEarly, onSelect, chunkAcc, None).flatMap {
-      case Some((chunk, idx, rest, chunkAcc)) =>
-        go(chunk, idx, rest, selector, emitNonSelected, wrap, emitEarly, onSelect, chunkAcc)
-      case None =>
-        Pull.done
-    }
+    filterChunk(chunk, idx, rest, selector, emitNonSelected, wrap, emitEarly, context, onSelect, chunkAcc, None)
+      .flatMap {
+        case Some((chunk, idx, rest, chunkAcc)) =>
+          go(chunk, idx, rest, selector, emitNonSelected, wrap, emitEarly, context, onSelect, chunkAcc)
+        case None =>
+          Pull.done
+      }
 
   def pipe[F[_]](selector: Selector, wrap: Boolean)(implicit F: RaiseThrowable[F]): Pipe[F, Token, Token] =
-    s => go(Chunk.empty, 0, s, selector, false, wrap, true, emit[F], Nil).stream
+    s => go(Chunk.empty, 0, s, selector, false, wrap, true, JsonContext.Root, emit[F], Nil).stream
 
-  def transformPipe[F[_], Json: Builder: Tokenizer](selector: Selector, f: Json => Option[Json])(
-      implicit F: RaiseThrowable[F]): Pipe[F, Token, Token] =
-    s => go(Chunk.empty, 0, s, selector, true, true, false, transform[F, Json](f), Nil).stream
+  def transformPipe[F[_], Json: Builder: Tokenizer](selector: Selector, f: Json => Option[Json])(implicit
+      F: RaiseThrowable[F]): Pipe[F, Token, Token] =
+    s => go(Chunk.empty, 0, s, selector, true, true, false, JsonContext.Root, transform[F, Json](f), Nil).stream
 
-  def transformPipeF[F[_], Json: Builder: Tokenizer](selector: Selector, f: Json => F[Json])(
-      implicit F: RaiseThrowable[F]): Pipe[F, Token, Token] =
-    s => go(Chunk.empty, 0, s, selector, true, true, true, transformF[F, Json](f), Nil).stream
+  def transformPipeF[F[_], Json: Builder: Tokenizer](selector: Selector, f: Json => F[Json])(implicit
+      F: RaiseThrowable[F]): Pipe[F, Token, Token] =
+    s => go(Chunk.empty, 0, s, selector, true, true, true, JsonContext.Root, transformF[F, Json](f), Nil).stream
 
-  private def emit[F[_]](
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      chunkAcc: List[Token],
-      key: Option[String])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+  private def emit[F[_]](chunk: Chunk[Token],
+                         idx: Int,
+                         rest: Stream[F, Token],
+                         context: JsonContext,
+                         chunkAcc: List[Token],
+                         key: Option[String])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
     emitValue[F](chunk, idx, rest, 0, chunkAcc)
 
-  private def transform[F[_], Json: Builder: Tokenizer](f: Json => Option[Json])(
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      chunkAcc: List[Token],
-      key: Option[String])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
-    transformValue(chunk, idx, rest, f, chunkAcc, key)
+  private def transform[F[_], Json: Builder: Tokenizer](f: Json => Option[Json])(chunk: Chunk[Token],
+                                                                                 idx: Int,
+                                                                                 rest: Stream[F, Token],
+                                                                                 context: JsonContext,
+                                                                                 chunkAcc: List[Token],
+                                                                                 key: Option[String])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+    transformValue(chunk, idx, rest, f, context, chunkAcc, key)
 
-  private def transformF[F[_], Json: Builder: Tokenizer](f: Json => F[Json])(
-      chunk: Chunk[Token],
-      idx: Int,
-      rest: Stream[F, Token],
-      chunkAcc: List[Token],
-      key: Option[String])(implicit F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
-    transformValueF(chunk, idx, rest, f, chunkAcc, key)
+  private def transformF[F[_], Json: Builder: Tokenizer](f: Json => F[Json])(chunk: Chunk[Token],
+                                                                             idx: Int,
+                                                                             rest: Stream[F, Token],
+                                                                             context: JsonContext,
+                                                                             chunkAcc: List[Token],
+                                                                             key: Option[String])(implicit
+      F: RaiseThrowable[F]): Pull[F, Token, Result[F, Token, List[Token]]] =
+    transformValueF(chunk, idx, rest, f, context, chunkAcc, key)
+
 
 }

--- a/json/shared/src/test/scala/fs2/data/json/JsonSelectorSpec.scala
+++ b/json/shared/src/test/scala/fs2/data/json/JsonSelectorSpec.scala
@@ -163,7 +163,12 @@ abstract class JsonSelectorSpec[Json](implicit builder: Builder[Json], tokenizer
         .compile
         .toList
         .unsafeRunSync()
-    transformed shouldBe List(Right(Token.StartObject), Right(Token.Key("f")), Left(exn))
+    transformed match {
+      case List(Right(Token.StartObject), Right(Token.Key("f")), Left(error: JsonException)) =>
+        error.context shouldBe Some(JsonContext.Key("f", JsonContext.Root))
+        error.inner shouldBe exn
+      case _ => fail()
+    }
   }
 
 }


### PR DESCRIPTION
This PR intentionally restricts the context to filtering and transformation. It induces overhead which might degrade general parsing too much and even prevent from parsing deeply nested JSON values. Restricting to selectors is ok as the context will be as deep as the selector, independently of the JSON value.