### PR TITLE
Add a csv 'attempt' variant to allow for by-row error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ site/output
 .metals/
 .bloop/
 metals.sbt
+
+.vscode/settings.json

--- a/csv/shared/src/main/scala/fs2/data/csv/internals/CsvRowParser.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/internals/CsvRowParser.scala
@@ -23,22 +23,28 @@ import cats.data._
 
 private[csv] object CsvRowParser {
 
-  def pipe[F[_], Header](implicit F: RaiseThrowable[F],
-                         Header: ParseableHeader[Header]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
+  def pipe[F[_], Header](implicit
+      F: RaiseThrowable[F],
+      Header: ParseableHeader[Header]
+  ): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
+    _.through(pipeAttempt[F, Header]).rethrow
+
+  /** Like `pipe` except that instead of failing the stream on parse errors, it emits `Left` elements for bad rows */
+  def pipeAttempt[F[_], Header](implicit
+      F: RaiseThrowable[F],
+      Header: ParseableHeader[Header]
+  ): Pipe[F, NonEmptyList[String], Either[Throwable, CsvRow[Header]]] =
     _.pull.uncons1.flatMap {
-      case Some((currentRow, tail)) =>
-        Header(currentRow) match {
-          case Left(error) => Pull.raiseError[F](error)
-          case Right(headers) if headers.length =!= currentRow.length =>
-            val error = new HeaderSizeError(
-              s"Got ${headers.length} headers, but ${currentRow.length} columns. Both numbers must match!",
-              expectedColumns = headers.length,
-              actualColumns = currentRow.length)
-            Pull.raiseError[F](error)
+      case Some((firstRow, tail)) =>
+        Header(firstRow) match {
+          case Left(error) => Pull.output1(Left(error))
+          case Right(headers) if headers.length =!= firstRow.length =>
+            val error = new HeaderError(
+              s"Got ${headers.length} headers, but ${firstRow.length} columns. Both numbers must match!")
+            Pull.output1(Left(error))
           case Right(headers) =>
             tail
               .map(CsvRow(_, headers))
-              .rethrow
               .pull
               .echo
         }

--- a/csv/shared/src/main/scala/fs2/data/csv/package.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/package.scala
@@ -65,6 +65,12 @@ package object csv {
                             Header: ParseableHeader[Header]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =
     CsvRowParser.pipe[F, Header]
 
+  /** Transforms a stream of raw CSV rows into parsed CSV rows with headers, with failures at the element level instead of failing the stream */
+  def headersAttempt[F[_], Header](
+      implicit F: RaiseThrowable[F],
+      Header: ParseableHeader[Header]): Pipe[F, NonEmptyList[String], Either[Throwable, CsvRow[Header]]] =
+    CsvRowParser.pipeAttempt[F, Header]
+
   /** Transforms a stream of raw CSV rows into parsed CSV rows with given headers. */
   def withHeaders[F[_], Header](headers: NonEmptyList[Header])(
       implicit F: RaiseThrowable[F]): Pipe[F, NonEmptyList[String], CsvRow[Header]] =


### PR DESCRIPTION

The use case for this is code that wants to parse an unreliable file, discard
"bad" rows, but continue to preserve the "good" rows, rather than failing the
whole process