### PR TITLE
Switch to new contextual-core library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val circeVersion = "0.13.0"
 val shapelessVersion = "2.3.3"
 
 val commonSettings = List(
-  scalaVersion := scala212,
+  scalaVersion := scala213,
   crossScalaVersions := Seq(scala213, scala212),
   organization := "org.gnieh",
   headerLicense := Some(HeaderLicense.ALv2("2021", "Lucas Satabin")),
@@ -187,7 +187,7 @@ lazy val jsonInterpolators = project
     name := "fs2-data-json-interpolators",
     description := "Json interpolators support",
     libraryDependencies ++= List(
-      "com.propensive" %% "contextual" % "1.2.1",
+      "com.propensive" %% "contextual-core" % "3.0.1",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )
   )

--- a/json/interpolators/src/main/scala/fs2/data/json/interpolators/package.scala
+++ b/json/interpolators/src/main/scala/fs2/data/json/interpolators/package.scala
@@ -17,12 +17,15 @@ package fs2
 package data
 package json
 
-import contextual.Prefix
+import contextual.Macros
+
+import language.experimental.macros
 
 package object interpolators {
 
   implicit class SelectorStringContext(sc: StringContext) {
-    val selector = Prefix(SelectorInterpolator, sc)
+    def selector(expressions: String*): Selector =
+      macro Macros.contextual[SelectorInterpolator.type]
   }
 
 }


### PR DESCRIPTION
This version also fixes the problem with scala 2.13, which we can now
use as default scala version for documentation.