### PR TITLE
#45: Add @CsvEmbed

### DIFF
--- a/csv/generic/src/main/scala/fs2/data/csv/generic/CsvEmbed.scala
+++ b/csv/generic/src/main/scala/fs2/data/csv/generic/CsvEmbed.scala
@@ -1,0 +1,7 @@
+package fs2.data.csv.generic
+
+import scala.annotation.Annotation
+
+/** Mark a field of a case class to be embedded (= to be parsed from the same row, but inlined as value)
+  */
+case class CsvEmbed() extends Annotation

--- a/csv/generic/src/main/scala/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
+++ b/csv/generic/src/main/scala/fs2/data/csv/generic/DerivedCsvRowDecoder.scala
@@ -24,14 +24,14 @@ trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, String]
 
 object DerivedCsvRowDecoder {
 
-  final implicit def productReader[T, Repr <: HList, DefaultRepr <: HList, AnnoRepr <: HList](implicit
+  final implicit def productReader[T, Repr <: HList, DefaultRepr <: HList, NamesAnno <: HList, EmbedsAnno <: HList](
+      implicit
       gen: LabelledGeneric.Aux[T, Repr],
       defaults: Default.AsOptions.Aux[T, DefaultRepr],
-      annotations: Annotations.Aux[CsvName, T, AnnoRepr],
-      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
-    new DerivedCsvRowDecoder[T] {
-      def apply(row: CsvRow[String]): DecoderResult[T] =
-        cc.value.fromWithDefault(row, defaults(), annotations()).map(gen.from(_))
-    }
+      names: Annotations.Aux[CsvName, T, NamesAnno],
+      embeds: Annotations.Aux[CsvEmbed, T, EmbedsAnno],
+      cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[T, Repr, DefaultRepr, NamesAnno, EmbedsAnno]])
+      : DerivedCsvRowDecoder[T] =
+    (row: CsvRow[String]) => cc.value.fromWithDefault(row, defaults(), names(), embeds()).map(gen.from(_))
 
 }

--- a/csv/generic/src/main/scala/fs2/data/csv/generic/DerivedCsvRowEncoder.scala
+++ b/csv/generic/src/main/scala/fs2/data/csv/generic/DerivedCsvRowEncoder.scala
@@ -24,10 +24,11 @@ trait DerivedCsvRowEncoder[T] extends CsvRowEncoder[T, String]
 
 object DerivedCsvRowEncoder {
 
-  final implicit def productWriter[T, Repr <: HList, AnnoRepr <: HList](implicit
+  final implicit def productWriter[T, Repr <: HList, NameAnno <: HList, EmbedAnno <: HList](implicit
       gen: LabelledGeneric.Aux[T, Repr],
-      annotations: Annotations.Aux[CsvName, T, AnnoRepr],
-      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[T, Repr, AnnoRepr]]): DerivedCsvRowEncoder[T] =
-    (elem: T) => cc.value.fromWithAnnotation(gen.to(elem), annotations())
+      names: Annotations.Aux[CsvName, T, NameAnno],
+      embeds: Annotations.Aux[CsvEmbed, T, EmbedAnno],
+      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[T, Repr, NameAnno, EmbedAnno]]): DerivedCsvRowEncoder[T] =
+    (elem: T) => cc.value.fromWithAnnotation(gen.to(elem), names(), embeds())
 
 }

--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -128,11 +128,20 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String], header
   def toMap(implicit hasHeaders: HasHeaders[H, Header]): Map[Header, String] =
     byHeader
 
-  /**
-    * Drop all headers (if any).
+  /** Drop all headers (if any).
     * @return a row without headers, but same values
     */
   def dropHeaders: Row = Row(values)
+
+  /** Concat this row with another. Header types must match, headers must be distinct.
+    * @param other the row to append
+    * @return a row combining both
+    */
+  def :::(other: RowF[H, Header]): RowF[H, Header] =
+    new RowF[H, Header](
+      values ::: other.values,
+      (headers: Option[NonEmptyList[Header]], other.headers).mapN(_ ::: _).asInstanceOf[H[NonEmptyList[Header]]]
+    )
 
   private def byHeader(implicit hasHeaders: HasHeaders[H, Header]): Map[Header, String] =
     headers.get.toList.zip(values.toList).toMap

--- a/csv/shared/src/main/scala/fs2/data/csv/exceptions.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/exceptions.scala
@@ -19,6 +19,14 @@ class CsvException(msg: String, inner: Throwable = null) extends Exception(msg, 
 
 class DecoderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)
 
+object DecoderError {
+
+  /** Signals that a column was missing. Use this exception in your own decoders in this case to ensure
+    * correct behaviour when using defaults and @CsvEmbed.
+    */
+  class ColumnMissing(msg: String, inner: Throwable = null) extends DecoderError(msg, inner)
+}
+
 class HeaderError(msg: String, inner: Throwable = null) extends CsvException(msg, inner)
 
 /** Raised when processing a Csv row whose width doesn't match the width of the Csv header row */

--- a/documentation/docs/csv/generic.md
+++ b/documentation/docs/csv/generic.md
@@ -131,5 +131,34 @@ val decoded = stream.through(headers[Fallible, String]).through(decodeRow[Fallib
 decoded.compile.toList
 ```
 
+#### Annotations for generic derivation on case classes
+The derivation of `CsvRowDecoder` and `CsvRowEncoder` cam be influenced by two annotations: `CsvName` and `CsvEmbed`.
+
+`CsvName` maps a field of the case class to a given header name in the CSV file. Example:
+
+```scala mdoc:nest
+import fs2.data.csv.generic.auto._
+
+case class MyRowRenamed(@CsvName("i") a: Int, j: Int, s: String)
+
+val decoded = stream.through(headers[Fallible, String]).through(decodeRow[Fallible, String, MyRowRenamed])
+decoded.compile.toList
+```
+
+`CsvEmbed` allows for encoding of non-flat case class hierarchies into the flat structure of a CSV file and vice versa. 
+The CSV must contain columns for all fields in the hierarchy which are not annotated with `CsvEmbed` (or have defaults). Example:
+
+```scala mdoc:nest
+import fs2.data.csv.generic.auto._
+
+case class Idx(i: Int)
+case class MyRowEmbed(@CsvEmbed ídx: Idx, j: Int, s: String)
+
+val decoded = stream.through(headers[Fallible, String]).through(decodeRow[Fallible, String, MyRowEmbed])
+decoded.compile.toList
+```
+
+NOTE: `CsvEmbed` and `CsvName` are mutually exclusive on the same field as the name of the embedded field is irrelevant.
+
 [csv-doc]: /documentation/csv/
 [shapeless]: https://github.com/milessabin/shapeless


### PR DESCRIPTION
Allows to map nested case class structures from and to flat CSV. See included docs for more info. Fixes #45.