### PR TITLE
Add some convenience CSV coders

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/RowDecoderF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowDecoderF.scala
@@ -1,6 +1,7 @@
 package fs2.data.csv
 
 import cats._
+import cats.data.{NonEmptyList, NonEmptyMap}
 import cats.implicits._
 
 import scala.annotation.tailrec
@@ -108,6 +109,17 @@ object RowDecoderF extends ExportedRowDecoderFs {
       def combineK[A](x: RowDecoderF[H, A, Header], y: RowDecoderF[H, A, Header]): RowDecoderF[H, A, Header] = x or y
     }
 
+  implicit def toMapCsvRowDecoder[Header]: CsvRowDecoder[Map[Header, String], Header] =
+    CsvRowDecoder.instance(_.toMap.asRight)
+
+  implicit def toNonEmptyMapCsvRowDecoder[Header: Order]: CsvRowDecoder[NonEmptyMap[Header, String], Header] =
+    CsvRowDecoder.instance(_.toNonEmptyMap.asRight)
+
+  implicit val toListRowDecoder: RowDecoder[List[String]] =
+    RowDecoder.instance(_.toList.asRight)
+
+  implicit val toNelRowDecoder: RowDecoder[NonEmptyList[String]] =
+    RowDecoder.instance(_.asRight)
 }
 
 trait ExportedRowDecoderFs {

--- a/csv/shared/src/main/scala/fs2/data/csv/RowEncoderF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowEncoderF.scala
@@ -16,6 +16,7 @@
 package fs2.data.csv
 
 import cats._
+import cats.data.{NonEmptyList, NonEmptyMap}
 
 import scala.annotation.implicitNotFound
 
@@ -45,6 +46,12 @@ object RowEncoderF extends ExportedRowEncoderFs {
 
   @inline
   def instance[H[+a] <: Option[a], T, Header](f: T => RowF[H, Header]): RowEncoderF[H, T, Header] = f(_)
+
+  implicit def fromNonEmptyMapCsvRowEncoder[Header: Order]: CsvRowEncoder[NonEmptyMap[Header, String], Header] =
+    CsvRowEncoder.instance(_.toNel)
+
+  implicit val fromNelRowEncoder: RowEncoder[NonEmptyList[String]] =
+    RowEncoder.instance(r => r)
 }
 
 trait ExportedRowEncoderFs {

--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -122,11 +122,15 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String], header
       case None    => Left(new DecoderError(s"unknown field $header"))
     }
 
-  /** Returns a map representation of this row if headers are defined, otherwise
-    * returns `None`.
+  /** Returns a representation of this row as Map from headers to corresponding cell values.
     */
   def toMap(implicit hasHeaders: HasHeaders[H, Header]): Map[Header, String] =
     byHeader
+
+  /** Returns a representation of this row as NonEmptyMap from headers to corresponding cell values.
+    */
+  def toNonEmptyMap(implicit hasHeaders: HasHeaders[H, Header], order: Order[Header]): NonEmptyMap[Header, String] =
+    headers.get.zip(values).toNem
 
   /** Drop all headers (if any).
     * @return a row without headers, but same values


### PR DESCRIPTION
Instances that come for free as their underlying collections are isomorphic to rows. Useful in combination with the new CSV pipes.