### PR TITLE
Replace contextual with literally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,7 +205,7 @@ lazy val jsonInterpolators = project
     name := "fs2-data-json-interpolators",
     description := "Json interpolators support",
     libraryDependencies ++= List(
-      "com.propensive" %% "contextual-core" % "3.0.0",
+      "org.typelevel" %% "literally" % "1.0.0",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )
   )

--- a/documentation/docs/json/interpolators.md
+++ b/documentation/docs/json/interpolators.md
@@ -6,7 +6,7 @@ module: json
 
 Module: [![Maven Central](https://img.shields.io/maven-central/v/org.gnieh/fs2-data-json-interpolators_2.13.svg)](https://mvnrepository.com/artifact/org.gnieh/fs2-data-json-interpolators_2.13)
 
-The `fs2-data-json-interpolators` module provides users with some useful string interpolators. The interpolators are based on [contextual][contextual] and are statically checked.
+The `fs2-data-json-interpolators` module provides users with some useful string interpolators. The interpolators are based on [literally][literally] and are statically checked.
 
 This page covers the following topics:
 * Contents
@@ -14,7 +14,7 @@ This page covers the following topics:
 
 ### Selector interpolator
 
-You can use the `selector` interpolator to parse a string.
+You can use the `selector` interpolator to parse a literal string.
 
 The example above can be rewritten as:
 ```scala mdoc
@@ -23,4 +23,4 @@ import fs2.data.json.interpolators._
 val selector = selector".field3.[]"
 ```
 
-[contextual]: https://propensive.com/opensource/contextual
+[literally]: https://github.com/typelevel/literally

--- a/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
+++ b/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
@@ -29,7 +29,7 @@ object SelectorInterpolator extends Literally[Selector] {
     new SelectorParser[Either[Throwable, *]](string).parse() match {
       case Left(JsonSelectorException(msg, idx)) => Left(s"$msg at index $idx")
       case Left(t)                               => Left(t.getMessage)
-      case Right(_)                              => Right(c.Expr(q"_root_.fs2.data.json.interpolators.SelectorParser.either($string).toOption.get"))
+      case Right(_)                              => Right(c.Expr(q"_root_.fs2.data.json.SelectorParser.either($string).toOption.get"))
     }
   }
 

--- a/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
+++ b/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
@@ -20,14 +20,19 @@ package interpolators
 
 import cats.implicits._
 
-import contextual._
+import org.typelevel.literally.Literally
 
-object SelectorInterpolator extends Verifier[Selector] {
+object SelectorInterpolator extends Literally[Selector] {
 
-  def check(string: String): Either[(Int, String), Selector] =
-    new SelectorParser[Either[Throwable, *]](string).parse().leftMap {
-      case JsonSelectorException(msg, idx) => (idx, msg)
-      case t                               => (0, t.getMessage)
+  def validate(c: Context)(string: String): Either[String, c.Expr[Selector]] = {
+    import c.universe._
+    new SelectorParser[Either[Throwable, *]](string).parse() match {
+      case Left(JsonSelectorException(msg, idx)) => Left(s"$msg at index $idx")
+      case Left(t)                               => Left(t.getMessage)
+      case Right(_)                              => Right(c.Expr(q"SelectorParser.either($string).toOption.get"))
     }
+  }
+
+  def make(c: Context)(args: c.Expr[Any]*): c.Expr[Selector] = apply(c)(args: _*)
 
 }

--- a/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
+++ b/json/interpolators/src/main/scala/fs2/data/json/interpolators/SelectorInterpolator.scala
@@ -29,7 +29,7 @@ object SelectorInterpolator extends Literally[Selector] {
     new SelectorParser[Either[Throwable, *]](string).parse() match {
       case Left(JsonSelectorException(msg, idx)) => Left(s"$msg at index $idx")
       case Left(t)                               => Left(t.getMessage)
-      case Right(_)                              => Right(c.Expr(q"SelectorParser.either($string).toOption.get"))
+      case Right(_)                              => Right(c.Expr(q"_root_.fs2.data.json.interpolators.SelectorParser.either($string).toOption.get"))
     }
   }
 

--- a/json/interpolators/src/main/scala/fs2/data/json/interpolators/package.scala
+++ b/json/interpolators/src/main/scala/fs2/data/json/interpolators/package.scala
@@ -17,12 +17,12 @@ package fs2
 package data
 package json
 
-import contextual.Prefix
+import scala.language.experimental.macros
 
 package object interpolators {
 
-  implicit class SelectorStringContext(sc: StringContext) {
-    val selector = Prefix(SelectorInterpolator, sc)
+  implicit class JsonSelectorStringContext(val sc: StringContext) extends AnyVal {
+    def selector(args: Any*): Selector = macro SelectorInterpolator.make
   }
 
 }

--- a/json/interpolators/src/test/scala/fs2/data/json/interpolators/JsonInterpolatorsTest.scala
+++ b/json/interpolators/src/test/scala/fs2/data/json/interpolators/JsonInterpolatorsTest.scala
@@ -1,0 +1,12 @@
+package fs2.data.json.interpolators
+
+import fs2.data.json.SelectorParser
+import weaver._
+
+object JsonInterpolatorsTest extends SimpleIOSuite {
+
+  pureTest("handles a selector literal correctly") {
+    expect(Right(selector".[].b.c") == new SelectorParser[Either[Throwable, *]](".[].b.c").parse())
+  }
+
+}

--- a/json/shared/src/main/scala/fs2/data/json/SelectorParser.scala
+++ b/json/shared/src/main/scala/fs2/data/json/SelectorParser.scala
@@ -311,18 +311,23 @@ class SelectorParser[F[_]](val input: String)(implicit F: MonadError[F, Throwabl
 
 }
 
-private object SelectorParser {
-  sealed trait Token {
+object SelectorParser {
+  def apply[F[_]](input: String)(implicit F: MonadError[F, Throwable]): F[Selector] =
+    new SelectorParser[F](input).parse()
+  // Mostly here for the literal selector macro, makes it simpler (esp with macro+kind-projector interaction)
+  def either(input: String): Either[Throwable, Selector] = apply[Either[Throwable, *]](input)
+
+  private sealed trait Token {
     val idx: Int
   }
-  case class LeftBracket(idx: Int) extends Token
-  case class RightBracket(idx: Int) extends Token
-  case class Dot(idx: Int) extends Token
-  case class Colon(idx: Int) extends Token
-  case class Comma(idx: Int) extends Token
-  case class QuestionMark(idx: Int) extends Token
-  case class Bang(idx: Int) extends Token
-  case class Str(s: String, idx: Int) extends Token
-  case class Name(s: String, idx: Int) extends Token
-  case class Integer(i: Int, idx: Int) extends Token
+  private case class LeftBracket(idx: Int) extends Token
+  private case class RightBracket(idx: Int) extends Token
+  private case class Dot(idx: Int) extends Token
+  private case class Colon(idx: Int) extends Token
+  private case class Comma(idx: Int) extends Token
+  private case class QuestionMark(idx: Int) extends Token
+  private case class Bang(idx: Int) extends Token
+  private case class Str(s: String, idx: Int) extends Token
+  private case class Name(s: String, idx: Int) extends Token
+  private case class Integer(i: Int, idx: Int) extends Token
 }


### PR DESCRIPTION
As contextual isn't moving towards Scala 3 (yet), this PR replaces it with the smaller, more focused and perfectly cross-building typelevel/literally lib.

A modified extract from #150 to make this change before the next RC.