### PR TITLE
Fix makeSite and sbt deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val commonSettings = List(
 )
 
 val publishSettings = List(
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   pomIncludeRepository := { x =>
     false
   },
@@ -67,17 +67,11 @@ val root = (project in file("."))
   .settings(
     name := "fs2-data",
     publishArtifact := false,
-    skip in publish := true,
-    unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(benchmarks,
-                                                                               csv.js,
-                                                                               csvGeneric.js,
-                                                                               json.js,
-                                                                               jsonCirce.js,
-                                                                               jsonDiffson.js,
-                                                                               xml.js,
-                                                                               cbor.js),
-    siteSubdirName in ScalaUnidoc := "api",
-    addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc),
+    publish / skip := true,
+    ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject --
+      inProjects(benchmarks, cbor.js, csv.js, csvGeneric.js, json.js, jsonCirce.js, jsonDiffson.js, text.js, xml.js),
+    ScalaUnidoc / siteSubdirName := "api",
+    addMappingsToSiteDir(ScalaUnidoc / packageDoc / mappings, ScalaUnidoc / siteSubdirName),
     Nanoc / sourceDirectory := file("site"),
     git.remoteRepo := scmInfo.value.get.connection.replace("scm:git:", ""),
     ghpagesNoJekyll := true


### PR DESCRIPTION
With the exclusion of the `text.js` module the site should build properly again (see https://github.com/sbt/sbt-unidoc/issues/21). And sbt 1.5.0 brought some deprecation warnings about syntax that are also fixed in this PR.

@satabin A RC2 after this one (then including the website update as the pipeline should no longer fail)?