### PR TITLE
Add a way to set a value that adds missing column

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/CsvRow.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/CsvRow.scala
@@ -111,6 +111,17 @@ case class CsvRow[Header] private[csv] (override val values: NonEmptyList[String
   def updated(header: Header, value: String): CsvRow[Header] =
     updated(headers.toList.indexOf(header), value)
 
+  /** Returns the row with the cell at `header` set to `value`.
+    * If the row does not contain this header yet, it is added to the end.
+    */
+  def set(header: Header, value: String): CsvRow[Header] = {
+    val idx = headers.toList.indexOf(header)
+    if(idx < 0)
+      new CsvRow[Header](values :+ value, headers :+ header)
+    else
+      updated(idx, value)
+  }
+
   /** Returns the row without the cell at the given `idx`.
     * If the resulting row is empty, returns `None`.
     */

--- a/csv/shared/src/test/scala/fs2/data/csv/CsvRowTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/CsvRowTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data.csv
+package generic
+
+import cats.data.NonEmptyList
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CsvRowTest extends AnyFlatSpec with Matchers {
+
+  val csvRow = new CsvRow(NonEmptyList.of("1", "test", "42"), NonEmptyList.of("i", "s", "j"))
+
+  "setting a value at a header" should "add the header if it is missing" in {
+    val result = csvRow.set("k", "new")
+    result.values shouldBe NonEmptyList.of("1", "test", "42", "new")
+    result.headers shouldBe NonEmptyList.of("i", "s", "j", "k")
+  }
+
+  it should "replace the value if it exists" in {
+    val result = csvRow.set("s", "new")
+    result.values shouldBe NonEmptyList.of("1", "new", "42")
+    result.headers shouldBe NonEmptyList.of("i", "s", "j")
+  }
+
+}


### PR DESCRIPTION
This new function adds the missing header in case it was not present in
the original row.
Due to potential problem implementing a correct behavior for index based
setting in case of rows with headers, this function is only added for
name based access.
A new function is added, not to break existing code with the former
behavior of ignoring missing headers.

This is the 0.x port of #217 