### PR TITLE
Make it possible to add a column by header name

### DIFF
--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -83,6 +83,21 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
   def updated(header: Header, value: String)(implicit hasHeaders: HasHeaders[H, Header]): CsvRow[Header] =
     hasHeaders(updatedAt(headers.get.toList.indexOf(header), value))
 
+  /** Returns the row with the cell at `header` modified to `value`.
+    * If the header wasn't present in the row, it is added to the end of the fields.
+    *
+    * **Note:** Only the first occurrence of the values with the given header
+    * will be modified. It shouldn't be a problem in the general case as headers
+    * should not be duplicated.
+    */
+  def set(header: Header, value: String)(implicit hasHeaders: HasHeaders[H, Header]): CsvRow[Header] = {
+    val idx = headers.get.toList.indexOf(header)
+    if (idx < 0)
+      hasHeaders(new RowF(values :+ value, headers.map(_ :+ header).asInstanceOf[H[NonEmptyList[Header]]]))
+    else
+      hasHeaders(updatedAt(idx, value))
+  }
+
   /** Returns the row without the cell at the given `idx`.
     * If the resulting row is empty, returns `None`.
     */

--- a/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/RowFTest.scala
@@ -1,0 +1,20 @@
+package fs2.data.csv
+
+import weaver._
+import cats.data.NonEmptyList
+
+object RowFTest extends SimpleIOSuite {
+
+  pureTest("RowF.set should change the value at existing header") {
+    val row = CsvRow.unsafe(NonEmptyList.of("1", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    expect.eql(NonEmptyList.of("1", "4", "3"), row.set("b", "4").values)
+  }
+
+  pureTest("RowF.set should add the value at end of row in case of missing header") {
+    val row = CsvRow.unsafe(NonEmptyList.of("1", "2", "3"), NonEmptyList.of("a", "b", "c"))
+    val extended = row.set("d", "4")
+    expect.eql(NonEmptyList.of("1", "2", "3", "4"), extended.values) and
+      expect.eql(NonEmptyList.of("a", "b", "c", "d"), extended.headers.get)
+  }
+
+}


### PR DESCRIPTION
This new operators allows for adding a column if the row initially
didn't have the header. In this case the column is added to the end of
the row.