### PR TITLE
Add support for codecs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val scalaJavaTimeVersion = "2.3.0"
 val diffsonVersion = "4.1.1"
 
 val commonSettings = List(
-  scalaVersion := scala3,
+  scalaVersion := scala213,
   crossScalaVersions := Seq(scala213, scala212, scala3),
   // Copied from circe
   Compile / unmanagedSourceDirectories ++= {
@@ -300,7 +300,8 @@ lazy val documentation = project
       "org.gnieh" %% "diffson-circe" % diffsonVersion,
       "io.circe" %% "circe-generic-extras" % circeVersion,
       "co.fs2" %% "fs2-io" % fs2Version
-    )
+    ),
+    scalacOptions += "-Ymacro-annotations"
   )
   .dependsOn(csv.jvm, csvGeneric.jvm, json.jvm, jsonDiffson.jvm, jsonCirce.jvm, jsonInterpolators, xml.jvm, cbor.jvm)
 

--- a/documentation/docs/json/libraries.md
+++ b/documentation/docs/json/libraries.md
@@ -13,8 +13,6 @@ This page covers the following libraries:
 Examples on this page use the following input:
 
 ```scala mdoc
-import cats.effect._
-
 import fs2.{Fallible, Stream}
 import fs2.data.json._
 import fs2.data.json.selector._
@@ -47,10 +45,10 @@ For instance both examples from the [core module documentation][json-doc] with c
 import fs2.data.json.circe._
 import io.circe._
 
-val asts = stream.through(values[Fallible, Json])
+val asts = stream.through(ast.values[Fallible, Json])
 asts.compile.toList
 
-val transformed = stream.through(transform[Fallible, Json](sel, json => Json.obj("test" -> json)))
+val transformed = stream.through(ast.transform[Fallible, Json](sel, json => Json.obj("test" -> json)))
 transformed.compile.to(collector.pretty())
 ```
 
@@ -63,7 +61,51 @@ import cats.implicits._
 
 val f1 = root.field("field1").compile
 
-val transformed = stream.through(transformOpt[Fallible, Json](f1, json => json.as[Int].toOption.filter(_ > 1).as(json)))
+val transformed = stream.through(ast.transformOpt[Fallible, Json](f1, json => json.as[Int].toOption.filter(_ > 1).as(json)))
+transformed.compile.to(collector.pretty())
+```
+
+The circe integration also provides `Deserializer` and `Serializer` based on the circe `Decoder`s and `Encoder`s.
+
+Let's say we defined our data model as follows:
+```scala mdoc
+import io.circe.generic.JsonCodec
+
+@JsonCodec
+case class Data(field1: Int, field2: Option[String], field3: List[Int])
+
+@JsonCodec
+case class WrappedData(field1: Int, field2: Option[String], field3: List[Wrapped])
+
+@JsonCodec
+case class Wrapped(test: Int)
+```
+ We could write the previous wrapping transformation using these case classes.
+
+```scala mdoc:nest
+import fs2.data.json.circe._
+import io.circe._
+
+val values = stream.through(codec.deserialize[Fallible, Data])
+values.compile.toList
+
+def wrap(data: Data): WrappedData =
+  WrappedData(data.field1, data.field2, data.field3.map(Wrapped(_)))
+
+val transformed = stream.through(codec.transform(sel, wrap))
+transformed.compile.to(collector.pretty())
+```
+
+Dropping values can be done similarly.
+
+```scala mdoc:nest
+import fs2.data.json.circe._
+import io.circe._
+import cats.implicits._
+
+val f1 = root.field("field1").compile
+
+val transformed = stream.through(codec.transformOpt(f1, (i: Int) => (i > 0).guard[Option].as(i)))
 transformed.compile.to(collector.pretty())
 ```
 

--- a/documentation/docs/json/patches.md
+++ b/documentation/docs/json/patches.md
@@ -20,8 +20,6 @@ In order for patches to be applied, you need a `Tokenizer` for some `Json` type 
 
 Let's say you are using circe as Json AST library, you can use patches like this:
 ```scala mdoc
-import cats.effect._
-
 import fs2.{Fallible, Stream}
 import fs2.data.json._
 import fs2.data.json.circe._

--- a/json/shared/src/main/scala/fs2/data/json/ast/package.scala
+++ b/json/shared/src/main/scala/fs2/data/json/ast/package.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data.json
+
+import internals.{TokenSelector, ValueParser}
+
+import cats.syntax.all._
+
+package object ast {
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged.
+    *
+    * This operator locally creates Json AST values using the [[Builder]], and
+    * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
+    */
+  def transform[F[_], Json](selector: Selector, f: Json => Json)(implicit
+      F: RaiseThrowable[F],
+      builder: Builder[Json],
+      tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
+    TokenSelector.transformPipe[F, Json, Json, Json](selector, _.asRight, f, _.some, true)
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * If the function returns `None`, then the entire value is dropped (and the object key it
+    * is located at, if any).
+    * The rest of the stream is left unchanged.
+    *
+    * This operator locally creates Json AST values using the [[Builder]], and
+    * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
+    */
+  def transformOpt[F[_], Json](selector: Selector, f: Json => Option[Json])(implicit
+      F: RaiseThrowable[F],
+      builder: Builder[Json],
+      tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
+    TokenSelector.transformPipe[F, Json, Json, Option[Json]](selector, _.asRight, f, identity, false)
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged. The operation can fail, in case the returned
+    * `F` is failed at one step.
+    *
+    * This operator locally creates Json AST values using the [[Builder]], and
+    * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
+    */
+  def transformF[F[_], Json](selector: Selector, f: Json => F[Json])(implicit
+      F: RaiseThrowable[F],
+      builder: Builder[Json],
+      tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
+    TokenSelector.transformPipeF[F, Json, Json, Json](selector, _.asRight, f, _.some, true)
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged. The operation can fail, in case the returned
+    * `F` is failed at one step.
+    *
+    * This operator locally creates Json AST values using the [[Builder]], and
+    * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
+    */
+  def transformOptF[F[_], Json](selector: Selector, f: Json => F[Option[Json]])(implicit
+      F: RaiseThrowable[F],
+      builder: Builder[Json],
+      tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
+    TokenSelector.transformPipeF[F, Json, Json, Option[Json]](selector, _.asRight, f, identity, false)
+
+  /** Transforms a stream of Json tokens into a stream of json values.
+    */
+  def values[F[_], Json](implicit F: RaiseThrowable[F], builder: Builder[Json]): Pipe[F, Token, Json] =
+    ValueParser.pipe[F, Json]
+
+  /** Transforms a stream of Json values into a stream of Json tokens.
+    *
+    * This operation is the opposite of `values`.
+    */
+  def tokenize[F[_], Json](implicit tokenizer: Tokenizer[Json]): Pipe[F, Json, Token] =
+    _.flatMap(value => Stream.emits(tokenizer.tokenize(value).toList))
+
+}

--- a/json/shared/src/main/scala/fs2/data/json/codec/Deserializer.scala
+++ b/json/shared/src/main/scala/fs2/data/json/codec/Deserializer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2.data.json
+package codec
+
+import ast.Builder
+
+/** Tells how some Json AST is deserialized into some value.
+  */
+trait Deserializer[A] {
+  type Json
+  implicit val builder: Builder[Json]
+  def deserialize(json: Json): Either[JsonException, A]
+}
+
+object Deserializer {
+  type Aux[A, J] = Deserializer[A] { type Json = J }
+}

--- a/json/shared/src/main/scala/fs2/data/json/codec/Serializer.scala
+++ b/json/shared/src/main/scala/fs2/data/json/codec/Serializer.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2.data.json
+package codec
+
+import ast.Tokenizer
+
+/** Tells how a value is serialized into Json. */
+trait Serializer[A] {
+  type Json
+  implicit val tokenizer: Tokenizer[Json]
+  def serialize(a: A): Json
+}
+
+object Serializer {
+  type Aux[A, J] = Serializer[A] { type Json = J }
+}

--- a/json/shared/src/main/scala/fs2/data/json/codec/package.scala
+++ b/json/shared/src/main/scala/fs2/data/json/codec/package.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fs2
+package data.json
+
+import internals._
+
+import cats.syntax.all._
+
+package object codec {
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged.
+    *
+    * This operator locally deserializes the Json values using the [[Deserializer]], and
+    * returns tokens as emitted by the [[Serializer]] on the resulting value.
+    */
+  def transform[F[_], A, B, Json](selector: Selector, f: A => B)(implicit
+      F: RaiseThrowable[F],
+      deserializer: Deserializer.Aux[A, Json],
+      serializer: Serializer.Aux[B, Json]): Pipe[F, Token, Token] = {
+    import deserializer.builder
+    import serializer.tokenizer
+    TokenSelector
+      .transformPipe[F, Json, A, B](selector, deserializer.deserialize, f, serializer.serialize(_).some, true)
+  }
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * If the function returns `None`, then the entire value is dropped (and the object key it
+    * is located at, if any).
+    * The rest of the stream is left unchanged.
+    *
+    * This operator locally deserializes Json values using the [[Deserializer]], and
+    * returns tokens as emitted by the [[Serializer]] on the resulting value.
+    */
+  def transformOpt[F[_], A, B, Json](selector: Selector, f: A => Option[B])(implicit
+      F: RaiseThrowable[F],
+      deserializer: Deserializer.Aux[A, Json],
+      serializer: Serializer.Aux[B, Json]): Pipe[F, Token, Token] = {
+    import deserializer.builder
+    import serializer.tokenizer
+    TokenSelector
+      .transformPipe[F, Json, A, Option[B]](selector, deserializer.deserialize, f, _.map(serializer.serialize), false)
+  }
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged. The operation can fail, in case the returned
+    * `F` is failed at one step.
+    *
+    * This operator locally deserializes Json values using the [[Deserializer]], and
+    * returns tokens as emitted by the [[Serializer]] on the resulting value.
+    */
+  def transformF[F[_], A, B, Json](selector: Selector, f: A => F[B])(implicit
+      F: RaiseThrowable[F],
+      deserializer: Deserializer.Aux[A, Json],
+      serializer: Serializer.Aux[B, Json]): Pipe[F, Token, Token] = {
+    import deserializer.builder
+    import serializer.tokenizer
+    TokenSelector
+      .transformPipeF[F, Json, A, B](selector, deserializer.deserialize, f, serializer.serialize(_).some, true)
+  }
+
+  /** Transforms a stream of token into another one. The transformation function `f` is
+    * called on every selected value from upstream, and the resulting value replaces it.
+    * The rest of the stream is left unchanged. The operation can fail, in case the returned
+    * `F` is failed at one step.
+    *
+    * This operator locally deserializes Json values using the [[Deserializer]], and
+    * returns tokens as emitted by the [[Serializer]] on the resulting value.
+    */
+  def transformOptF[F[_], A, B, Json](selector: Selector, f: A => F[Option[B]])(implicit
+      F: RaiseThrowable[F],
+      deserializer: Deserializer.Aux[A, Json],
+      serializer: Serializer.Aux[B, Json]): Pipe[F, Token, Token] = {
+    import deserializer.builder
+    import serializer.tokenizer
+    TokenSelector
+      .transformPipeF[F, Json, A, Option[B]](selector, deserializer.deserialize, f, _.map(serializer.serialize), false)
+  }
+
+  /** Transforms a stream of Json tokens into a stream of deserialized values.
+    */
+  def deserialize[F[_], A](implicit F: RaiseThrowable[F], deserializer: Deserializer[A]): Pipe[F, Token, A] = {
+    import deserializer.builder
+    _.through(ast.values[F, deserializer.Json]).map(deserializer.deserialize).rethrow
+  }
+
+  /** Transforms a stream of values into a stream of Json tokens.
+    *
+    * This operation is the opposite of `deserialize`.
+    */
+  def serialize[F[_], A](implicit serializer: Serializer[A]): Pipe[F, A, Token] = {
+    import serializer.tokenizer
+    _.map(serializer.serialize(_)).through(ast.tokenize)
+  }
+
+}

--- a/json/shared/src/main/scala/fs2/data/json/package.scala
+++ b/json/shared/src/main/scala/fs2/data/json/package.scala
@@ -49,11 +49,12 @@ package object json {
     * This operator locally creates Json AST values using the [[Builder]], and
     * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
     */
+  @deprecated(message = "Use `fs2.data.json.ast.transform` instead", since = "1.3.0")
   def transform[F[_], Json](selector: Selector, f: Json => Json)(implicit
       F: RaiseThrowable[F],
       builder: Builder[Json],
       tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
-    TokenSelector.transformPipe[F, Json](selector, f.andThen(Some(_)))
+    ast.transform(selector, f)
 
   /** Transforms a stream of token into another one. The transformation function `f` is
     * called on every selected value from upstream, and the resulting value replaces it.
@@ -64,11 +65,12 @@ package object json {
     * This operator locally creates Json AST values using the [[Builder]], and
     * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
     */
+  @deprecated(message = "Use `fs2.data.json.ast.transformOpt` instead", since = "1.3.0")
   def transformOpt[F[_], Json](selector: Selector, f: Json => Option[Json])(implicit
       F: RaiseThrowable[F],
       builder: Builder[Json],
       tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
-    TokenSelector.transformPipe[F, Json](selector, f)
+    ast.transformOpt(selector, f)
 
   /** Transforms a stream of token into another one. The transformation function `f` is
     * called on every selected value from upstream, and the resulting value replaces it.
@@ -78,23 +80,26 @@ package object json {
     * This operator locally creates Json AST values using the [[Builder]], and
     * returns tokens as emitted by the [[Tokenizer]] on the resulting value.
     */
+  @deprecated(message = "Use `fs2.data.json.ast.transformF` instead", since = "1.3.0")
   def transformF[F[_], Json](selector: Selector, f: Json => F[Json])(implicit
       F: RaiseThrowable[F],
       builder: Builder[Json],
       tokenizer: Tokenizer[Json]): Pipe[F, Token, Token] =
-    TokenSelector.transformPipeF[F, Json](selector, f)
+    ast.transformF(selector, f)
 
   /** Transforms a stream of Json tokens into a stream of json values.
     */
+  @deprecated(message = "Use `fs2.data.json.ast.values` instead", since = "1.3.0")
   def values[F[_], Json](implicit F: RaiseThrowable[F], builder: Builder[Json]): Pipe[F, Token, Json] =
-    ValueParser.pipe[F, Json]
+    ast.values[F, Json]
 
   /** Transforms a stream of Json values into a stream of Json tokens.
     *
     * This operation is the opposite of `values`.
     */
+  @deprecated(message = "Use `fs2.data.json.ast.tokenize` instead", since = "1.3.0")
   def tokenize[F[_], Json](implicit tokenizer: Tokenizer[Json]): Pipe[F, Json, Token] =
-    _.flatMap(value => Stream.emits(tokenizer.tokenize(value).toList))
+    ast.tokenize[F, Json]
 
   /** A collection of pipes to wrap streams inside objects. */
   object wrap {

--- a/json/shared/src/test/scala/fs2/data/json/JsonSelectorSpec.scala
+++ b/json/shared/src/test/scala/fs2/data/json/JsonSelectorSpec.scala
@@ -116,7 +116,7 @@ abstract class JsonSelectorSpec[Json](implicit builder: Builder[Json], tokenizer
              Token.Key("g"),
              Token.StringValue("test"),
              Token.EndObject)
-        .through(transformOpt[Fallible, Json](selector, _ => Some(builder.makeFalse)))
+        .through(ast.transformOpt[Fallible, Json](selector, _ => Some(builder.makeFalse)))
         .compile
         .toList
     expect(
@@ -138,7 +138,7 @@ abstract class JsonSelectorSpec[Json](implicit builder: Builder[Json], tokenizer
              Token.Key("g"),
              Token.StringValue("test"),
              Token.EndObject)
-        .through(transformOpt[Fallible, Json](selector, _ => None))
+        .through(ast.transformOpt[Fallible, Json](selector, _ => None))
         .compile
         .toList
     expect(transformed == Right(List(Token.StartObject, Token.Key("g"), Token.StringValue("test"), Token.EndObject)))
@@ -157,7 +157,7 @@ abstract class JsonSelectorSpec[Json](implicit builder: Builder[Json], tokenizer
         Token.Key("g"),
         Token.StringValue("test"),
         Token.EndObject
-      ).through(transformOpt[Fallible, Json](selector, _ => None)).compile.toList
+      ).through(ast.transformOpt[Fallible, Json](selector, _ => None)).compile.toList
     expect(
       transformed == Right(
         List(Token.StartObject,
@@ -181,7 +181,7 @@ abstract class JsonSelectorSpec[Json](implicit builder: Builder[Json], tokenizer
            Token.Key("g"),
            Token.StringValue("test"),
            Token.EndObject)
-      .through(transformF[IO, Json](selector, _ => IO.raiseError(exn)))
+      .through(ast.transformF[IO, Json](selector, _ => IO.raiseError(exn)))
       .attempt
       .compile
       .toList


### PR DESCRIPTION
In addition to parsing and transforming Json ASTs, this adds a way to
work with plain Scala value when the udnerlying Json library has some
concept of codecs.

This is also the oppportunity to rationalize the selector code a bit,
making the trasformation pipes more regular and generic.

Old `json` package level transform pipes are deprecated in favor of
their variant in the `ast` package. This allows for semantically scoped
transformation pipes.