### PR TITLE
Add CharLikeChunks for UTF-8

### DIFF
--- a/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
@@ -18,6 +18,7 @@ package fs2.data.csv
 import io.circe.parser.parse
 import fs2._
 import fs2.io.file.{Files, Flags, Path}
+import fs2.data.text.utf8._
 import cats.effect._
 import cats.syntax.all._
 import weaver._
@@ -50,7 +51,6 @@ object CsvParserTest extends SimpleIOSuite {
       .evalMap { case (path, expected) =>
         Files[IO]
           .readAll(path, 1024, Flags.Read)
-          .through(fs2.text.utf8.decode)
           .through(decodeUsingHeaders[CsvRow[String]]())
           .compile
           .toList

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -63,7 +63,7 @@ Files[IO]
 
 For textual data formats (JSON, XML, CSV, ...) this stream needs to be decoded according to the file encoding.
 
-#### UTF-8 and single byte encoded (ISO-8859-1, ISO-8859-15, ASCII) inputs
+#### Decoding textual inputs
 
 If your file is encoded using UTF-8 or a common single-byte encoding, you can use the built-in support `fs2-data` has for these encodings, which lives in the [`fs2.data.text` package][fs2-data-text-api].
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -63,29 +63,15 @@ Files[IO]
 
 For textual data formats (JSON, XML, CSV, ...) this stream needs to be decoded according to the file encoding.
 
-#### UTF-8 encoded inputs
+#### UTF-8 and single byte encoded (ISO-8859-1, ISO-8859-15, ASCII) inputs
 
-If your file is encoded in **UTF-8**, you can use the [`fs2.text` decoding pipes][fs2-decoders] to get a stream of strings, which can then be fed to the parsers:
-
-```scala mdoc:silent
-Files[IO]
-  .readAll(Path("/some/path/to/a/file.data"), 1024, Flags.Read)
-  // extra decoding step is required since UTF-8 encodes character input
-  // up to 4 bytes, which might span several chunks
-  .through(text.utf8.decode)
-  // now that we have a stream of `String`, we can parse
-  .through(tokens)
-  .compile
-  .drain
-```
-
-#### Single byte encoded (ISO-8859-1, ISO-8859-15, ASCII) inputs
-
-If your file is encoded using a single-byte encoding, there is no built-in decoder for this in `fs2`. However, `fs2-data` provides support for common single-byte encodings, which live in the [`fs2.data.text` package][fs2-data-text-api].
+If your file is encoded using UTF-8 or a common single-byte encoding, you can use the built-in support `fs2-data` has for these encodings, which lives in the [`fs2.data.text` package][fs2-data-text-api].
 
 ```scala mdoc:silent
 // for instance if your input is encoded in ISO-8859-1 aka latin1
 import fs2.data.text.latin1._
+// if you have UTF-8 instead:
+// import fs2.data.text.utf8._
 
 Files[IO]
   .readAll(Path("/some/path/to/a/file.data"), 1024, Flags.Read)

--- a/text/shared/src/main/scala/fs2/data/text/package.scala
+++ b/text/shared/src/main/scala/fs2/data/text/package.scala
@@ -20,6 +20,23 @@ import java.nio.charset.{Charset, StandardCharsets}
 
 package object text {
 
+  /** Import this if your byte stream is encoded in UTF-8 */
+  object utf8 {
+
+    implicit def byteStreamCharLike[F[_]]: CharLikeChunks[F, Byte] = {
+      val stringsCharLike = CharLikeChunks.stringStreamCharLike[F]
+      new CharLikeChunks[F, Byte] {
+        override type Context = stringsCharLike.Context
+        override def create(s: Stream[F, Byte]): Context = stringsCharLike.create(s.through(fs2.text.utf8.decode))
+        override def needsPull(ctx: Context): Boolean = stringsCharLike.needsPull(ctx)
+        override def pullNext(ctx: Context): Pull[F, INothing, Option[Context]] = stringsCharLike.pullNext(ctx)
+        override def advance(ctx: Context): Context = stringsCharLike.advance(ctx)
+        override def current(ctx: Context): Char = stringsCharLike.current(ctx)
+      }
+    }
+
+  }
+
   /** Import this if your byte stream is encoded in ISO-8859-1 (aka latin1) */
   object latin1 {
 


### PR DESCRIPTION
Add `CharLikeChunks` instance for UTF-8 to ease use (for users it's not clear why they can get ISO-8859-1 & Co via import and not UTF-8). Its implementation is basically what users are currently expected to do themselves, just wrapped up for convenience.