### PR TITLE
Make it possible to keep comments

### DIFF
--- a/xml/src/main/scala/fs2/data/xml/XmlEvent.scala
+++ b/xml/src/main/scala/fs2/data/xml/XmlEvent.scala
@@ -51,4 +51,6 @@ object XmlEvent {
 
   case object EndDocument extends XmlEvent
 
+  case class Comment(comment: String) extends XmlEvent
+
 }

--- a/xml/src/main/scala/fs2/data/xml/internals/MarkupToken.scala
+++ b/xml/src/main/scala/fs2/data/xml/internals/MarkupToken.scala
@@ -40,8 +40,8 @@ private object MarkupToken {
     def render: String = s"<!$name"
   }
 
-  case object CommentToken extends MarkupToken {
-    def render: String = "<!-- ... -->"
+  case class CommentToken(content: Option[String]) extends MarkupToken {
+    def render: String = s"<!-- ${content.getOrElse("...")} -->"
   }
 
   case object CDataToken extends MarkupToken {

--- a/xml/src/main/scala/fs2/data/xml/package.scala
+++ b/xml/src/main/scala/fs2/data/xml/package.scala
@@ -29,11 +29,24 @@ package object xml {
 
   /** Transforms a stream of characters into a stream of XML events.
     * Emitted tokens are guaranteed to be valid up to that point.
-    * If the streams ends without failure, the sequence of tokens is sensured
+    * If the streams ends without failure, the sequence of tokens is ensured
     * to represent a (potentially empty) sequence of valid XML documents.
     */
+  @deprecated(message = "Use `fs2.data.xml.events()` instead.", since = "fs2-data 1.4.0")
   def events[F[_], T](implicit F: RaiseThrowable[F], T: CharLikeChunks[F, T]): Pipe[F, T, XmlEvent] =
-    EventParser.pipe[F, T]
+    EventParser.pipe[F, T](false)
+
+  /** Transforms a stream of characters into a stream of XML events.
+    * Emitted tokens are guaranteed to be valid up to that point.
+    * If the streams ends without failure, the sequence of tokens is ensured
+    * to represent a (potentially empty) sequence of valid XML documents.
+    *
+    * if `includeComments` is `true`, then comment events will be emitted
+    * together with the comment content.
+    */
+  def events[F[_], T](
+      includeComments: Boolean = false)(implicit F: RaiseThrowable[F], T: CharLikeChunks[F, T]): Pipe[F, T, XmlEvent] =
+    EventParser.pipe[F, T](includeComments)
 
   /** Resolves the character and entity references in the XML stream.
     * Entities are already defined and validated (especially no recursion),

--- a/xml/src/test/scala/fs2/data/xml/XmlExceptionSpec.scala
+++ b/xml/src/test/scala/fs2/data/xml/XmlExceptionSpec.scala
@@ -25,7 +25,7 @@ object XmlExceptionSpec extends SimpleIOSuite {
 
     val input = """<a><b>c</a>"""
 
-    val stream = Stream.emit(input).through(events[Fallible, String]).attempt
+    val stream = Stream.emit(input).through(events[Fallible, String]()).attempt
 
     expect(stream.compile.toList match {
       case Right(


### PR DESCRIPTION
Comments can be useful to keep when transforming XML from source to
source.