### PR TITLE
Allow for XML postlog

### DIFF
--- a/xml/scala-xml/src/main/scala/fs2/data/xml/scalaXml/package.scala
+++ b/xml/scala-xml/src/main/scala/fs2/data/xml/scalaXml/package.scala
@@ -37,12 +37,13 @@ package object scalaXml {
                      standalone: Option[Boolean],
                      doctype: Option[XmlEvent.XmlDoctype],
                      prolog: List[Misc],
-                     root: Elem): Document = {
+                     root: Elem,
+                     postlog: List[Misc]): Document = {
       val document = new Document()
       document.version = version
       document.encoding = encoding
       document.standAlone = standalone
-      document.children = prolog :+ root
+      document.children = prolog ++ (root :: postlog)
       document.docElem = root.head
       document
     }

--- a/xml/src/main/scala/fs2/data/xml/dom/DocumentBuilder.scala
+++ b/xml/src/main/scala/fs2/data/xml/dom/DocumentBuilder.scala
@@ -29,7 +29,8 @@ trait DocumentBuilder[Document] {
                    standalone: Option[Boolean],
                    doctype: Option[XmlEvent.XmlDoctype],
                    prolog: List[Misc],
-                   root: Elem): Document
+                   root: Elem,
+                   postlog: List[Misc]): Document
 
   def makeComment(content: String): Option[Misc]
 

--- a/xml/src/test/scala/fs2/data/xml/dom/EventifierSpec.scala
+++ b/xml/src/test/scala/fs2/data/xml/dom/EventifierSpec.scala
@@ -28,11 +28,13 @@ abstract class EventifierSpec[Doc](implicit builder: DocumentBuilder[Doc], event
     val input = Stream.emits("""<?xml version="1.1" encoding="utf-8"?>
                                |<a att1="value1" att2="&amp; another one">
                                |  <!-- a comment -->
-                               |  <b>Test</b>
+                               |  <b><![CDATA[Test]]></b>
                                |  <b/>
-                               |</a>""".stripMargin)
+                               |</a>
+                               |<?target content?>
+                               |<!-- closing comment -->""".stripMargin)
 
-    val evts = input.through(events[Fallible, Char]())
+    val evts = input.through(events[Fallible, Char](true))
 
     val roundtrip = evts.through(documents).through(eventify)
 


### PR DESCRIPTION
The specification allows for `misc` appearing after the root element,
and the event parser should support this, as well as the document
builder.

Since a stream can contain concatenated XML documents, a choice has to
be made regarding how misc is associated between 2 documents in the
stream. This implementation makes the choice to associate the misc as
postlog of the previous document since it allows to emit early without
knowing what comes next (i.e. whether the stream actually contains only
one document or several documents).