### PR TITLE
Introduce StaticHeaders type class for CSV

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,14 +255,25 @@ lazy val csvGeneric = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       }
       .toList
       .flatten,
-    // Filter related to DerivedCellDecoder come from removed implicit params. These are only the Java forwarders.
     mimaBinaryIssueFilters ++= List(
+      // Filter related to DerivedCellDecoder come from removed implicit params. These are only the Java forwarders.
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "fs2.data.csv.generic.internal.DerivedCellDecoder.decodeCCons"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "fs2.data.csv.generic.internal.DerivedCellDecoder.decodeCConsObjAnnotated"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.data.csv.generic.internal.DerivedCellDecoder.decodeCConsObj")
+        "fs2.data.csv.generic.internal.DerivedCellDecoder.decodeCConsObj"),
+      // Filters changes related to internals of generic derivation. While technically public,
+      // one should only run into issues if relied on internals of the generic derivation,
+      // which is far from recommended use cases
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "fs2.data.csv.generic.internal.DerivedCsvRowEncoder.headers"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.fromWithAnnotation"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.headers"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.rawRow")
     )
   )
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)

--- a/build.sbt
+++ b/build.sbt
@@ -268,12 +268,16 @@ lazy val csvGeneric = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       // which is far from recommended use cases
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
         "fs2.data.csv.generic.internal.DerivedCsvRowEncoder.headers"),
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+        "fs2.data.csv.generic.internal.DerivedCsvRowDecoder.headers"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.fromWithAnnotation"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
         "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.headers"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.rawRow")
+        "fs2.data.csv.generic.internal.LowPrioMapShapedCsvRowEncoderImplicits#WithAnnotations.rawRow"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.data.csv.generic.internal.LowPriorityMapShapedCsvRowDecoder1#WithDefaults.headers")
     )
   )
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % scalaJavaTimeVersion % Test)

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowDecoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowDecoder.scala
@@ -16,11 +16,12 @@
 
 package fs2.data.csv.generic.internal
 
+import cats.data.NonEmptyList
 import fs2.data.csv.generic.CsvName
-import fs2.data.csv.{CsvRow, CsvRowDecoder, DecoderResult}
-import shapeless._
+import fs2.data.csv.{CsvRow, CsvRowDecoder, DecoderResult, StaticHeaders}
+import shapeless.*
 
-trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, String]
+trait DerivedCsvRowDecoder[T] extends CsvRowDecoder[T, String] with StaticHeaders[T, String]
 
 object DerivedCsvRowDecoder {
 
@@ -29,9 +30,11 @@ object DerivedCsvRowDecoder {
       defaults: Default.AsOptions.Aux[T, DefaultRepr],
       annotations: Annotations.Aux[CsvName, T, AnnoRepr],
       cc: Lazy[MapShapedCsvRowDecoder.WithDefaults[Repr, DefaultRepr, AnnoRepr]]): DerivedCsvRowDecoder[T] =
-    new DerivedCsvRowDecoder[T] {
+    new DerivedCsvRowDecoder[T] with StaticHeaders[T, String] {
+      private val annos: AnnoRepr = annotations()
       def apply(row: CsvRow[String]): DecoderResult[T] =
-        cc.value.fromWithDefault(row, defaults(), annotations()).map(gen.from(_))
+        cc.value.fromWithDefault(row, defaults(), annos).map(gen.from(_))
+      override lazy val headers: NonEmptyList[String] = NonEmptyList.fromListUnsafe(cc.value.headers(annos))
     }
 
 }

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowEncoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/DerivedCsvRowEncoder.scala
@@ -16,18 +16,25 @@
 
 package fs2.data.csv.generic.internal
 
-import fs2.data.csv.CsvRowEncoder
+import cats.data.NonEmptyList
+import fs2.data.csv.{CsvRow, CsvRowEncoder, StaticHeaders}
 import fs2.data.csv.generic.CsvName
 import shapeless._
 
-trait DerivedCsvRowEncoder[T] extends CsvRowEncoder[T, String]
+trait DerivedCsvRowEncoder[T] extends CsvRowEncoder[T, String] with StaticHeaders[T, String]
 
 object DerivedCsvRowEncoder {
 
   final implicit def productWriter[T, Repr <: HList, AnnoRepr <: HList](implicit
       gen: LabelledGeneric.Aux[T, Repr],
       annotations: Annotations.Aux[CsvName, T, AnnoRepr],
-      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[Repr, AnnoRepr]]): DerivedCsvRowEncoder[T] =
-    (elem: T) => cc.value.fromWithAnnotation(gen.to(elem), annotations())
+      cc: Lazy[MapShapedCsvRowEncoder.WithAnnotations[Repr, AnnoRepr]]): DerivedCsvRowEncoder[T] = {
+    val annos = annotations()
+    new DerivedCsvRowEncoder[T] {
+      override val headers: NonEmptyList[String] = NonEmptyList.fromListUnsafe(cc.value.headers(annos))
+      override def apply(elem: T): CsvRow[String] =
+        CsvRow.unsafe(NonEmptyList.fromListUnsafe(cc.value.rawRow(gen.to(elem))), headers)
+    }
+  }
 
 }

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowDecoder.scala
@@ -16,11 +16,11 @@
 
 package fs2.data.csv.generic.internal
 
-import cats.syntax.all._
-import fs2.data.csv._
+import cats.syntax.all.*
+import fs2.data.csv.*
 import fs2.data.csv.generic.CsvName
-import shapeless._
-import shapeless.labelled._
+import shapeless.*
+import shapeless.labelled.*
 
 trait MapShapedCsvRowDecoder[Repr] extends CsvRowDecoder[Repr, String]
 
@@ -30,6 +30,7 @@ object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
     new WithDefaults[HNil, HNil, HNil] {
       def fromWithDefault(row: CsvRow[String], default: HNil, annotation: HNil): DecoderResult[HNil] =
         Right(HNil)
+      override def headers(annotation: HNil): List[String] = Nil
     }
 
   implicit def optionHconsRowDecoder[Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
@@ -52,6 +53,9 @@ object MapShapedCsvRowDecoder extends LowPriorityMapShapedCsvRowDecoder1 {
           tail <- Tail.value.fromWithDefault(row, default.tail, anno.tail)
         } yield field[Key](head) :: tail
       }
+
+      override def headers(anno: Anno :: AnnoTail): List[String] =
+        anno.head.fold(witness.value.name)(_.name) :: Tail.value.headers(anno.tail)
     }
 
 }
@@ -60,6 +64,7 @@ private[generic] trait LowPriorityMapShapedCsvRowDecoder1 {
 
   trait WithDefaults[Repr, DefaultRepr, AnnoRepr] {
     def fromWithDefault(row: CsvRow[String], default: DefaultRepr, annotation: AnnoRepr): DecoderResult[Repr]
+    def headers(annotation: AnnoRepr): List[String]
   }
 
   implicit def hconsRowDecoder[Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
@@ -87,6 +92,9 @@ private[generic] trait LowPriorityMapShapedCsvRowDecoder1 {
           tail <- Tail.value.fromWithDefault(row, default.tail, anno.tail)
         } yield field[Key](head) :: tail
       }
+
+      override def headers(anno: Anno :: AnnoTail): List[String] =
+        anno.head.fold(witness.value.name)(_.name) :: Tail.value.headers(anno.tail)
     }
 
 }

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowEncoder.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/internal/MapShapedCsvRowEncoder.scala
@@ -16,9 +16,8 @@
 
 package fs2.data.csv.generic.internal
 
-import cats.data.NonEmptyList
 import fs2.data.csv.generic.CsvName
-import fs2.data.csv.{CellEncoder, CsvRow, CsvRowEncoder}
+import fs2.data.csv.{CellEncoder, CsvRowEncoder}
 import shapeless._
 import shapeless.labelled._
 
@@ -30,15 +29,19 @@ object MapShapedCsvRowEncoder extends LowPrioMapShapedCsvRowEncoderImplicits {
       Last: CellEncoder[Repr],
       ev: <:<[Anno, Option[CsvName]],
       witness: Witness.Aux[Key]): WithAnnotations[FieldType[Key, Repr] :: HNil, Anno :: HNil] =
-    (row: Repr :: HNil, annotation: Anno :: HNil) =>
-      CsvRow.unsafe(NonEmptyList.one(Last(row.head)),
-                    NonEmptyList.one(annotation.head.fold(witness.value.name)(_.name)))
+    new WithAnnotations[FieldType[Key, Repr] :: HNil, Anno :: HNil] {
+      override def headers(annotation: Anno :: HNil): List[String] =
+        annotation.head.fold(witness.value.name)(_.name) :: Nil
+      override def rawRow(repr: FieldType[Key, Repr] :: HNil): List[String] =
+        Last(repr.head) :: Nil
+    }
 
 }
 
 private[generic] trait LowPrioMapShapedCsvRowEncoderImplicits {
   trait WithAnnotations[Repr, AnnoRepr] {
-    def fromWithAnnotation(row: Repr, annotation: AnnoRepr): CsvRow[String]
+    def headers(annotation: AnnoRepr): List[String]
+    def rawRow(repr: Repr): List[String]
   }
 
   implicit def hconsRowEncoder[Key <: Symbol, Head, Tail <: HList, DefaultTail <: HList, Anno, AnnoTail <: HList](
@@ -46,10 +49,13 @@ private[generic] trait LowPrioMapShapedCsvRowEncoderImplicits {
       witness: Witness.Aux[Key],
       Head: CellEncoder[Head],
       ev: <:<[Anno, Option[CsvName]],
-      Tail: Lazy[WithAnnotations[Tail, AnnoTail]]): WithAnnotations[FieldType[Key, Head] :: Tail, Anno :: AnnoTail] =
-    (row: FieldType[Key, Head] :: Tail, annotation: Anno :: AnnoTail) => {
-      val tailRow = Tail.value.fromWithAnnotation(row.tail, annotation.tail)
-      CsvRow.unsafe(NonEmptyList(Head(row.head), tailRow.values.toList),
-                    NonEmptyList(annotation.head.fold(witness.value.name)(_.name), tailRow.headers.get.toList))
+      Tail: Lazy[WithAnnotations[Tail, AnnoTail]]): WithAnnotations[FieldType[Key, Head] :: Tail, Anno :: AnnoTail] = {
+    val tail = Tail.value
+    new WithAnnotations[FieldType[Key, Head] :: Tail, Anno :: AnnoTail] {
+      override def headers(annotation: Anno :: AnnoTail): List[String] =
+        annotation.head.fold(witness.value.name)(_.name) :: tail.headers(annotation.tail)
+      override def rawRow(repr: FieldType[Key, Head] :: Tail): List[String] =
+        Head(repr.head) :: tail.rawRow(repr.tail)
     }
+  }
 }

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/semiauto.scala
@@ -33,7 +33,7 @@ object semiauto {
   def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, String] =
     T.value
 
-  def deriveCsvRowEncoder[T](implicit T: Lazy[DerivedCsvRowEncoder[T]]): CsvRowEncoder[T, String] =
+  def deriveCsvRowEncoder[T](implicit T: Lazy[DerivedCsvRowEncoder[T]]): StaticCsvRowEncoder[T, String] =
     T.value
 
   def deriveCellDecoder[T](implicit T: Lazy[DerivedCellDecoder[T]]): CellDecoder[T] =

--- a/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-2/fs2/data/csv/generic/semiauto.scala
@@ -30,7 +30,7 @@ object semiauto {
   def deriveRowEncoder[T](implicit T: Lazy[DerivedRowEncoder[T]]): RowEncoder[T] =
     T.value
 
-  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): CsvRowDecoder[T, String] =
+  def deriveCsvRowDecoder[T](implicit T: Lazy[DerivedCsvRowDecoder[T]]): StaticCsvRowDecoder[T, String] =
     T.value
 
   def deriveCsvRowEncoder[T](implicit T: Lazy[DerivedCsvRowEncoder[T]]): StaticCsvRowEncoder[T, String] =

--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
@@ -52,7 +52,7 @@ import scala.annotation.nowarn
 
   def deriveRowEncoder[T](using ic: K0.ProductInstances[CellEncoder, T]): RowEncoder[T] = new RowEncoder[T] {
     override def apply(elem: T): Row = Row(
-      cats.data.NonEmptyList
+      NonEmptyList
         .fromListUnsafe(ic.foldLeft(elem)(List.empty[String])([t] =>
           (acc: List[String], ce: CellEncoder[t], e: t) => Continue[List[String]](ce(e) :: acc)))
         .reverse)
@@ -76,15 +76,18 @@ import scala.annotation.nowarn
   }
 
   def deriveCsvRowEncoder[T](using ic: K0.ProductInstances[CellEncoder, T], naming: Names[T]) =
-    new CsvRowEncoder[T, String] {
+    new CsvRowEncoder[T, String] with StaticHeaders[T, String] {
       val names: List[String] = naming.names
       type Acc = (List[String], List[(String, String)])
+
+      override val headers: NonEmptyList[String] = NonEmptyList.fromListUnsafe(names)
+
       override def apply(elem: T): CsvRow[String] = {
         val columns = ic
           .foldLeft[Acc](elem)(names -> List.empty[(String, String)])([t] =>
             (acc: Acc, ce: CellEncoder[t], e: t) => Continue((acc._1.tail, ((acc._1.head -> ce(e)) :: acc._2))))
           ._2
-        CsvRow.fromNelHeaders(cats.data.NonEmptyList.fromListUnsafe(columns.reverse))
+        CsvRow.fromNelHeaders(NonEmptyList.fromListUnsafe(columns.reverse))
       }
     }
 
@@ -104,7 +107,7 @@ import scala.annotation.nowarn
 
   private[generic] def deriveCsvRowEncoder[T](ic: K0.ProductInstances[CellEncoder, T],
                                               labels: Labelling[T],
-                                              annotations: Annotations[CsvName, T]): CsvRowEncoder[T, String] = {
+                                              annotations: Annotations[CsvName, T]): StaticCsvRowEncoder[T, String] = {
     given Labelling[T] = labels
     given Annotations[CsvName, T] = annotations
     deriveCsvRowEncoder[T](using ic = ic, naming = summon[Names[T]])

--- a/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
+++ b/csv/generic/shared/src/main/scala-3/fs2/data/csv/generic/semiauto.scala
@@ -60,9 +60,9 @@ import scala.annotation.nowarn
 
   def deriveCsvRowDecoder[T](using
       ic: K0.ProductInstances[OptCellDecoder, T],
-      naming: Names[T]): CsvRowDecoder[T, String] = {
+      naming: Names[T]): CsvRowDecoder[T, String] with StaticHeaders[T, String] = {
     val names: List[String] = naming.names
-    new CsvRowDecoder[T, String] {
+    new CsvRowDecoder[T, String] with StaticHeaders[T, String] {
       override def apply(row: CsvRow[String]): DecoderResult[T] = {
         ic.constructM[StateT[DecoderResult, List[(String, Option[String])], *]] { [t] => (cd: OptCellDecoder[t]) =>
           StateT[DecoderResult, List[(String, Option[String])], t] {
@@ -72,6 +72,8 @@ import scala.annotation.nowarn
         }(summon, summon, summon)
           .runA(names.map(name => name -> row(name)))
       }
+
+      override val headers: NonEmptyList[String] = NonEmptyList.fromListUnsafe(names)
     }
   }
 

--- a/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowDecoderTest.scala
+++ b/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowDecoderTest.scala
@@ -97,4 +97,13 @@ object CsvRowDecoderTest extends SimpleIOSuite {
     }
   }
 
+  pureTest("should provide static headers correctly") {
+    expect(testDecoder.headers == NonEmptyList.of("i", "s", "j")) and
+      expect(testOrderDecoder.headers == NonEmptyList.of("s", "j", "i")) and
+      expect(testRenameDecoder.headers == NonEmptyList.of("s", "j", "i")) and
+      expect(testOptionRenameDecoder.headers == NonEmptyList.of("s", "j", "i")) and
+      expect(testOptionalStringDecoder.headers == NonEmptyList.of("i", "s", "j")) and
+      expect(testDefaultsDecoder.headers == NonEmptyList.of("i", "j"))
+  }
+
 }

--- a/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowEncoderTest.scala
+++ b/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowEncoderTest.scala
@@ -61,4 +61,10 @@ object CsvRowEncoderTest extends SimpleIOSuite {
     }
   }
 
+  pureTest("should provide static headers correctly") {
+    expect(testEncoder.headers == NonEmptyList.of("i", "s", "j")) and
+      expect(testRenameEncoder.headers == NonEmptyList.of("i", "s", "j")) and
+      expect(testOptionRenameEncoder.headers == NonEmptyList.of("i", "s", "j"))
+  }
+
 }

--- a/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowEncoderTest.scala
+++ b/csv/generic/shared/src/test/scala/fs2/data/csv/generic/CsvRowEncoderTest.scala
@@ -55,4 +55,10 @@ object CsvRowEncoderTest extends SimpleIOSuite {
     expect(testOptionRenameEncoder(TestOptionRename(1, "test", Some(42))) == csvRow)
   }
 
+  pureTest("headers should be available statically") {
+    forEach(List(testEncoder, testRenameEncoder, testOptionRenameEncoder)) { encoder =>
+      expect(encoder.headers === NonEmptyList.of("i", "s", "j"))
+    }
+  }
+
 }

--- a/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/RowF.scala
@@ -214,10 +214,10 @@ case class RowF[H[+a] <: Option[a], Header](values: NonEmptyList[String],
       order: Order[Header]): NonEmptyMap[Header, String] =
     headers.get.zip(values).toNem
 
-  /** Drop all headers (if any).
+  /** Drop all headers (if any). Retains the line number if set.
     * @return a row without headers, but same values
     */
-  def dropHeaders: Row = Row(values)
+  def dropHeaders: Row = Row(values, line)
 
   // let's cache this to avoid recomputing it for every call to `as` or similar method
   // the `Option.get` call is safe since this field is only called in a context where a `HasHeaders`

--- a/csv/shared/src/main/scala/fs2/data/csv/StaticHeaders.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/StaticHeaders.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.data.csv
+
+import cats.Functor
+import cats.data.NonEmptyList
+
+/** Type class for types that have statically known headers. This is useful for encoding/decoding CSV rows
+ * where the headers are fixed and can be determined at compile time. */
+trait StaticHeaders[T, H] {
+  def headers: NonEmptyList[H]
+}
+
+object StaticHeaders {
+  @inline
+  def apply[T, H](implicit sh: StaticHeaders[T, H]): StaticHeaders[T, H] = sh
+
+  @inline
+  def instance[T, H](hs: NonEmptyList[H]): StaticHeaders[T, H] =
+    new StaticHeaders[T, H] {
+      override def headers: NonEmptyList[H] = hs
+    }
+
+  implicit def headerFunctor[T]: Functor[StaticHeaders[T, *]] = new Functor[StaticHeaders[T, *]] {
+    override def map[A, B](fa: StaticHeaders[T, A])(f: A => B): StaticHeaders[T, B] = instance(fa.headers.map(f))
+  }
+
+  implicit def forWriteableHeader[T, H](implicit
+      W: WriteableHeader[H],
+      H: StaticHeaders[T, H]): StaticHeaders[T, String] =
+    instance(WriteableHeader[H].apply(H.headers))
+}

--- a/csv/shared/src/main/scala/fs2/data/csv/package.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/package.scala
@@ -79,8 +79,17 @@ package object csv {
   /** Describes how a row can be encoded from a value of the given type.
     */
   @implicitNotFound(
-    "No implicit CsvRowEncoderF[H,  found for type ${T}.\nYou can define one using CsvRowEncoderF[H, .instance, by calling contramap on another CsvRowEncoderF[H,  or by using generic derivation for product types like case classes.\nFor that, add the fs2-data-csv-generic module to your dependencies and use either full-automatic derivation:\nimport fs2.data.csv.generic.auto._\nor the recommended semi-automatic derivation:\nimport fs2.data.csv.generic.semiauto._\nimplicit val csvRowEncoder: CsvRowEncoderF[H, [${T}] = deriveCsvRowEncoderF[H, \nMake sure to have instances of CellEncoder for every member type in scope.\n")
+    "No implicit CsvRowEncoder found for type ${T}.\nYou can define one using CsvRowEncoder.instance, by calling contramap on another CsvRowEncoder or by using generic derivation for product types like case classes.\nFor that, add the fs2-data-csv-generic module to your dependencies and use either full-automatic derivation:\nimport fs2.data.csv.generic.auto._\nor the recommended semi-automatic derivation:\nimport fs2.data.csv.generic.semiauto._\nimplicit val csvRowEncoder: CsvRowEncoder[${T}] = deriveCsvRowEncoder\nMake sure to have instances of CellEncoder for every member type in scope.\n")
   type CsvRowEncoder[T, Header] = RowEncoderF[Some, T, Header]
+
+  /**
+   * Convenience type alias for a [[CsvRowEncoder]] that also has a [[StaticHeaders]] instance,
+   * so that the headers are determined solely by the type and not the input data.
+   *
+   * This type should not be taken as implicit parameter, prefer taking the two type class instances separately,
+   * but it can be useful as a return type for functions that need both capabilities.
+   */
+  type StaticCsvRowEncoder[T, Header] = CsvRowEncoder[T, Header] & StaticHeaders[T, Header]
 
   @nowarn
   sealed trait QuoteHandling
@@ -258,6 +267,30 @@ package object csv {
         if (fullRows) lowlevel.toRowStrings[F](separator, newline, escape)
         else lowlevel.toStrings[F](separator, newline, escape)
       lowlevel.encodeRow[F, Header, T] andThen lowlevel.encodeRowWithFirstHeaders[F, Header] andThen stringPipe
+    }
+  }
+
+  /** Encode a specified type into a CSV using the headers from the [[StaticHeaders]] instance.
+   * If the input is empty, the headers will still be emitted. */
+  def encodeUsingStaticHeaders[T]: PartiallyAppliedEncodeUsingStaticHeaders[T] =
+    new PartiallyAppliedEncodeUsingStaticHeaders(dummy = true)
+
+  @nowarn
+  class PartiallyAppliedEncodeUsingStaticHeaders[T](val dummy: Boolean) extends AnyVal {
+    def apply[F[_]: RaiseThrowable, Header](fullRows: Boolean = false,
+                                            separator: Char = ',',
+                                            newline: String = "\n",
+                                            escape: EscapeMode = EscapeMode.Auto)(implicit
+        T: CsvRowEncoder[T, Header],
+        SH: StaticHeaders[T, Header],
+        H: WriteableHeader[Header]): Pipe[F, T, String] = {
+      val stringPipe =
+        if (fullRows) lowlevel.toRowStrings[F](separator, newline, escape)
+        else lowlevel.toStrings[F](separator, newline, escape)
+      lowlevel.encodeRow[F, Header, T] andThen
+        (_.map(_.dropHeaders)) andThen
+        lowlevel.writeWithGivenHeaders[F, Header](SH.headers) andThen
+        stringPipe
     }
   }
 

--- a/csv/shared/src/main/scala/fs2/data/csv/package.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/package.scala
@@ -91,6 +91,15 @@ package object csv {
    */
   type StaticCsvRowEncoder[T, Header] = CsvRowEncoder[T, Header] & StaticHeaders[T, Header]
 
+  /**
+   * Convenience type alias for a [[CsvRowDecoder]] that also has a [[StaticHeaders]] instance,
+   * so that the headers are determined solely by the type and not the input data.
+   *
+   * This type should not be taken as implicit parameter, prefer taking the two type class instances separately,
+   * but it can be useful as a return type for functions that need both capabilities.
+   */
+  type StaticCsvRowDecoder[T, Header] = CsvRowDecoder[T, Header] & StaticHeaders[T, Header]
+
   @nowarn
   sealed trait QuoteHandling
 

--- a/csv/shared/src/main/scala/fs2/data/csv/package.scala
+++ b/csv/shared/src/main/scala/fs2/data/csv/package.scala
@@ -189,6 +189,30 @@ package object csv {
     }
   }
 
+  /** Decode a char-like stream (see [[fs2.data.text.CharLikeChunks]]) into a specified type.
+   *
+   * Scenarios:
+   * - If skipHeaders is false, then the file contains no headers.
+   * - If skipHeaders is true, then the headers in the file will be skipped.
+   *
+   * For both scenarios the file is assumed to be compliant with the set of headers given via the instance of [[StaticHeaders]].
+   * It's equivalent to [[decodeGivenHeaders]] with headers from the [[StaticHeaders]] instance.
+   */
+  def decodeUsingStaticHeaders[T]: PartiallyAppliedDecodeUsingStaticHeaders[T] =
+    new PartiallyAppliedDecodeUsingStaticHeaders(dummy = true)
+
+  @nowarn
+  class PartiallyAppliedDecodeUsingStaticHeaders[T](val dummy: Boolean) extends AnyVal {
+    def apply[F[_], C, Header](skipHeaders: Boolean = false,
+                               separator: Char = ',',
+                               quoteHandling: QuoteHandling = QuoteHandling.RFCCompliant)(implicit
+        F: RaiseThrowable[F],
+        C: CharLikeChunks[F, C],
+        SH: StaticHeaders[T, Header],
+        T: CsvRowDecoder[T, Header]): Pipe[F, C, T] =
+      decodeGivenHeaders[T](SH.headers, skipHeaders, separator, quoteHandling)
+  }
+
   /** Encode a specified type into a CSV that contains no headers. */
   def encodeWithoutHeaders[T]: PartiallyAppliedEncodeWithoutHeaders[T] =
     new PartiallyAppliedEncodeWithoutHeaders[T](dummy = true)

--- a/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
+++ b/csv/shared/src/test/scala/fs2/data/csv/CsvParserTest.scala
@@ -507,4 +507,39 @@ object CsvParserTest extends SimpleIOSuite {
       case Left(x)       => failure(s"Stream failed with value $x")
     }
   }
+
+  test("empty CSV with headers should round-trip correctly") {
+    val content = "name,age,description\n"
+
+    case class Data(name: String, age: Int, description: String)
+
+    implicit val dataDecoder: CsvRowDecoder[Data, String] = (row: CsvRow[String]) =>
+      (
+        row.as[String]("name"),
+        row.as[Int]("age"),
+        row.as[String]("description")
+      ).mapN(Data.apply)
+
+    implicit val dataEncoder: CsvRowEncoder[Data, String] with StaticHeaders[Data, String] =
+      new CsvRowEncoder[Data, String] with StaticHeaders[Data, String] {
+        override val headers: NonEmptyList[String] = NonEmptyList.of("name", "age", "description")
+
+        override def apply(elem: Data): CsvRow[String] = CsvRow.fromNelHeaders(
+          NonEmptyList.of(
+            "name" -> elem.name,
+            "age" -> elem.age.toString,
+            "description" -> elem.description
+          )
+        )
+      }
+
+    Stream
+      .emit(content)
+      .covary[IO]
+      .through(decodeUsingHeaders[Data]())
+      .through(encodeUsingStaticHeaders[Data]())
+      .compile
+      .string
+      .map(actual => expect.eql(content, actual))
+  }
 }

--- a/site/documentation/csv/generic.md
+++ b/site/documentation/csv/generic.md
@@ -125,6 +125,10 @@ decoded.compile.toList
 
 It's important to note that by the limitations of the CSV file format, there's no clear notion of when default values would apply. `fs2-data-csv-generic` treats values as missing if there's no column with the expected name or if the value is empty. This implies that cells with an empty value won't be parsed of there's a default present, even if the corresponding `CellDecoder` instance could handle empty input, like `CellDecoder[String]`. If you need to handle empty inputs explicitly, refrain from defining a (non-empty) default or define the `CsvRowDecoder` instance manually. 
 
+### `StaticHeaders`
+
+Both automatic and semi-automatic derivation of `CsvRowDecoder` and `CsvRowEncoder` result in instances that also implement the `StaticHeaders` type class. This allows to them to be used with CSV pipes that rely on the header information being statically available, like `encodeUsingFirstHeaders` or `encodeUsingHeaders`. There's currently no stand-alone derivation of `StaticHeaders` instances.
+
 [csv-doc]: /documentation/csv/index.md
 [shapeless]: https://github.com/milessabin/shapeless
 [shapeless-3]: https://github.com/typelevel/shapeless-3

--- a/site/documentation/csv/index.md
+++ b/site/documentation/csv/index.md
@@ -49,10 +49,12 @@ More high-level pipes are available for the following use cases:
 * `decodeWithoutHeaders` for CSV parsing that requires no headers and none are present in the input (Note: requires `RowDecoder` instead of `CsvRowDecoder`)
 * `decodeSkippingHeaders` for CSV parsing that requires no headers, but they are present in the input (Note: requires `RowDecoder` instead of `CsvRowDecoder`)
 * `decodeGivenHeaders` for CSV parsing that requires headers, but they aren't present in the input
+* `decodeUsingStaticHeaders` for CSV parsing that requires headers which aren't present in the input, but provided through a `StaticHeaders` type class instance
 * `decodeUsingHeaders` for CSV parsing that requires headers and they're present in the input
 * `encodeWithoutHeaders` for CSV encoding that works entirely without headers (Note: requires `RowEncoder` instead of `CsvRowEncoder`)
 * `encodeWithGivenHeaders` for CSV encoding that works without headers, but they should be added to the output
 * `encodeUsingFirstHeaders` for CSV encoding that works with headers. Uses the headers of the first row for the output.
+* `encodeUsingStaticHeaders` for CSV encoding that works with headers. Uses the headers of a `StatisHeaders` type class instance to emit headers even if the output is empty.
 
 ### Dealing with erroneous files
 
@@ -335,6 +337,27 @@ decoded.compile.toList
 Analogously, you can encode your data with a `CsvRowEncoder`. Make sure to not vary the headers based on the data itself as this can't be reflected in the CSV format.
 
 As you can see this can be quite tedious to implement. Lucky us, the `fs2-data-csv-generic` module comes to the rescue to avoid having to write the boilerplate. Please refer to [the module documentation][csv-generic-doc] for more details.
+
+### `StaticHeaders`
+
+The `StaticHeaders` type class is used to provide headers for encoding and decoding when the headers aren't present in the input or output. It is used by the `decodeUsingStaticHeaders` and `encodeUsingStaticHeaders` pipes. It's signature is very simple:
+
+```scala
+trait StaticHeaders[T, H] {
+  def headers: NonEmptyList[H]
+}
+```
+
+where `T` is the type you want to decode/encode and `H` is the type of the headers (often `String`).
+While you can define your own stand-alone instance of `StaticHeaders` easily
+
+```scala
+implicit val staticHeadersForMyRow: StaticHeaders[MyRow, String] = StaticHeaders.instance(NonEmptyList.of("i", "s", "j"))
+```
+
+it is usually more practical to mix in the `StaticHeaders` trait into your `CsvRowDecoder` and `CsvRowEncoder` instances or rely on [generic derivation][csv-generic-doc] to get the `StaticHeaders` instance for free.
+
+```scala mdoc
 
 [nel]: https://typelevel.org/cats/datatypes/nel.html
 [rfc]: https://tools.ietf.org/html/rfc4180

--- a/site/documentation/csv/index.md
+++ b/site/documentation/csv/index.md
@@ -357,8 +357,6 @@ implicit val staticHeadersForMyRow: StaticHeaders[MyRow, String] = StaticHeaders
 
 it is usually more practical to mix in the `StaticHeaders` trait into your `CsvRowDecoder` and `CsvRowEncoder` instances or rely on [generic derivation][csv-generic-doc] to get the `StaticHeaders` instance for free.
 
-```scala mdoc
-
 [nel]: https://typelevel.org/cats/datatypes/nel.html
 [rfc]: https://tools.ietf.org/html/rfc4180
 [enumeratum]: https://github.com/lloydmeta/enumeratum/


### PR DESCRIPTION
Currently, the only way to create an empty CSV with headers is by using a pipe that takes explicit headers. The more comfortable `encodeUsingFirstHeaders` requires the CSV to be non-empty. 

This PR adds a `encodeUsingStaticHeaders` pipe that takes the necessary header information from a new type class `StaticHeaders`. To facilitate adoption, the generic derivation now derives `CsvRowEncoder` instances that also implement `StaticHeaders`.

Still missing, will add once it's clear this PR is going somewhere:
* MiMa exclusions – it's unhappy about changes in `generic` because `DerivedCsvRowEncoder` is public. I don't think it would be a problem
* Documentation on the website (Scaladoc is already there)