### PR TITLE
Remove expecty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,6 @@ val commonSettings = List(
     "co.fs2" %%% "fs2-io" % fs2Version % "test",
     "org.typelevel" %%% "weaver-cats" % weaverVersion % "test",
     "org.typelevel" %%% "weaver-scalacheck" % weaverVersion % Test,
-    "com.eed3si9n.expecty" %%% "expecty" % "0.17.1" % "test",
     "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3" cross CrossVersion.for3Use2_13
   ),
   scalacOptions := scalacOptions.value.filterNot(_ == "-source:3.0-migration"),


### PR DESCRIPTION
weaver dropped the usage of expecty [back in 0.9](https://github.com/typelevel/weaver-test/pull/64) and we're not using expecty directly, so we can remove it and save some CO2.

Probably worth adding some `clue` invocations in our tests to still get rich error messages, but I leave that to future self.