### PR TITLE
Fix CBOR<->JSON round-trips

### DIFF
--- a/cbor-json/shared/src/main/scala/fs2/data/json/package.scala
+++ b/cbor-json/shared/src/main/scala/fs2/data/json/package.scala
@@ -57,15 +57,19 @@ package object cbor {
     if (bd.isWhole) {
       if (bd >= 0) {
         val bi = bd.toBigInt
-        if (bi.isValidLong)
-          Chunk.singleton(CborItem.PositiveInt(ByteVector(bi.toByteArray)))
-        else
+        if (bi.isValidLong) {
+          val rawBytes = bi.toByteArray
+          val power2Length = if (rawBytes.length == 3) 4 else if (rawBytes.length > 4) 8 else rawBytes.length
+          Chunk.singleton(CborItem.PositiveInt(ByteVector(rawBytes).padLeft(power2Length)))
+        } else
           Chunk(CborItem.Tag(Tags.PositiveBigNum), CborItem.ByteString(ByteVector(bi.toByteArray).dropWhile(_ == 0x00)))
       } else {
         val bi = (bd.toBigInt + 1).abs
-        if (bi.isValidLong)
-          Chunk.singleton(CborItem.NegativeInt(ByteVector(bi.toByteArray)))
-        else
+        if (bi.isValidLong) {
+          val rawBytes = bi.toByteArray
+          val power2Length = if (rawBytes.length == 3) 4 else if (rawBytes.length > 4) 8 else rawBytes.length
+          Chunk.singleton(CborItem.NegativeInt(ByteVector(rawBytes).padLeft(power2Length)))
+        } else
           Chunk(CborItem.Tag(Tags.NegativeBigNum), CborItem.ByteString(ByteVector(bi.toByteArray).dropWhile(_ == 0x00)))
       }
     } else {

--- a/cbor-json/shared/src/main/scala/fs2/data/json/package.scala
+++ b/cbor-json/shared/src/main/scala/fs2/data/json/package.scala
@@ -60,7 +60,7 @@ package object cbor {
         if (bi.isValidLong) {
           val rawBytes = bi.toByteArray
           val power2Length = if (rawBytes.length == 3) 4 else if (rawBytes.length > 4) 8 else rawBytes.length
-          Chunk.singleton(CborItem.PositiveInt(ByteVector(rawBytes).padLeft(power2Length)))
+          Chunk.singleton(CborItem.PositiveInt(ByteVector(rawBytes).padLeft(power2Length.toLong)))
         } else
           Chunk(CborItem.Tag(Tags.PositiveBigNum), CborItem.ByteString(ByteVector(bi.toByteArray).dropWhile(_ == 0x00)))
       } else {
@@ -68,7 +68,7 @@ package object cbor {
         if (bi.isValidLong) {
           val rawBytes = bi.toByteArray
           val power2Length = if (rawBytes.length == 3) 4 else if (rawBytes.length > 4) 8 else rawBytes.length
-          Chunk.singleton(CborItem.NegativeInt(ByteVector(rawBytes).padLeft(power2Length)))
+          Chunk.singleton(CborItem.NegativeInt(ByteVector(rawBytes).padLeft(power2Length.toLong)))
         } else
           Chunk(CborItem.Tag(Tags.NegativeBigNum), CborItem.ByteString(ByteVector(bi.toByteArray).dropWhile(_ == 0x00)))
       }

--- a/cbor-json/shared/src/test/scala/fs2/data/cbor/JsonToCborSpec.scala
+++ b/cbor-json/shared/src/test/scala/fs2/data/cbor/JsonToCborSpec.scala
@@ -34,6 +34,7 @@ object JsonToCborSpec extends SimpleIOSuite {
           List(
             Token.NumberValue("0"),
             Token.NumberValue("10"),
+            Token.NumberValue("133456"),
             Token.NumberValue("-1"),
             Token.NumberValue("-20"),
             Token.NumberValue(Long.MinValue.toString()),
@@ -46,6 +47,7 @@ object JsonToCborSpec extends SimpleIOSuite {
       List(
         CborItem.PositiveInt(hex"00"),
         CborItem.PositiveInt(hex"0a"),
+        CborItem.PositiveInt(hex"00020950"),
         CborItem.NegativeInt(hex"00"),
         CborItem.NegativeInt(hex"13"),
         CborItem.NegativeInt(hex"7fffffffffffffff"),

--- a/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
+++ b/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
@@ -1,0 +1,31 @@
+package fs2
+package data
+
+import cats.effect.IO
+import fs2.data.cbor.high.CborValue
+import weaver.SimpleIOSuite
+
+object RoundtripSpec extends SimpleIOSuite {
+
+  test("CBOR items should round-trip through JSON") {
+    val items = List(
+      CborValue.Integer(123456), // 3 bytes
+      CborValue.Integer(1235213352876L), // 5 bytes
+      CborValue.TextString("Hello, world!"),
+      CborValue.True,
+      CborValue.False,
+      CborValue.Null
+    )
+
+    Stream
+      .emits(items)
+      .through(cbor.high.toItems)
+      .through(cbor.json.decodeItems[IO])
+      .through(json.cbor.encodeItems)
+      .through(cbor.high.parseValues)
+      .compile
+      .toList
+      .map { result => expect.same(items, result) }
+  }
+
+}

--- a/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
+++ b/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
@@ -14,7 +14,8 @@ object RoundtripSpec extends SimpleIOSuite {
       CborValue.TextString("Hello, world!"),
       CborValue.True,
       CborValue.False,
-      CborValue.Null
+      CborValue.Null,
+      CborValue.Float64(Math.PI)
     )
 
     Stream

--- a/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
+++ b/cbor-json/shared/src/test/scala/fs2/data/cbor/RoundtripSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 fs2-data Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2
 package data
 

--- a/cbor/shared/src/main/scala/fs2/data/cbor/high/internal/ValueParser.scala
+++ b/cbor/shared/src/main/scala/fs2/data/cbor/high/internal/ValueParser.scala
@@ -233,6 +233,16 @@ object ValueParser {
             case _ => Pull.raiseError(new CborTagDecodingException("A bignum must have a byte string as value"))
           }
           parseTags(chunk, idx + 1, rest, f(true), chunkAcc)
+        case CborItem.Tag(Tags.DecimalFraction) =>
+          def f(recurse: Boolean): CborValue => Pull[F, Nothing, CborValue] = {
+            case CborValue.Array(Seq(CborValue.Integer(exponent), CborValue.Integer(mantissa)), false) =>
+              tags(CborValue.Float64(mantissa.toDouble * Math.pow(10D, exponent.toDouble)))
+            case CborValue.Tagged(tag2, v) if recurse => tags(CborValue.Tagged(tag2, v)).flatMap(f(false))
+            case _                                    =>
+              Pull.raiseError(
+                new CborTagDecodingException("A decimal fraction must have an array of two integers as value"))
+          }
+          parseTags(chunk, idx + 1, rest, f(true), chunkAcc)
         case CborItem.Tag(tag) => parseTags(chunk, idx + 1, rest, v => tags(CborValue.Tagged(tag, v)), chunkAcc)
         case _                 => Pull.pure((chunk, idx, rest, chunkAcc, tags))
       }


### PR DESCRIPTION
This PR fixes two bugs in the CBOR handling, especially when used in conjunction with the JSON conversion features:
1. When JSON numbers are converted to CBOR, padding was missing, causing numbers that encode to a number of bytes that is not a power of 2 (aka 3, 5, 6, 7) to produce illegal CBOR.
2. `CborValue.Float64` is encoded as `Tagged(4, Array(Integer, Integer))` as mandated by the spec, but the `ValueParser` didn't handle this tag to re-construct the `Float64`value